### PR TITLE
Name parsing

### DIFF
--- a/server/routes/recognizeCard.js
+++ b/server/routes/recognizeCard.js
@@ -3,6 +3,7 @@ const { ImageAnnotatorClient } = require('@google-cloud/vision');
 const pokemon = require('pokemontcgsdk');
 const multer = require('multer');
 const router = express.Router();
+const { cleanName } = require('../util/stripName.js');
 
 // Configure Google Cloud Vision
 const client = new ImageAnnotatorClient({
@@ -32,7 +33,7 @@ router.post('/api/recognizeCard', upload.single('file'), async (req, res) => {
         console.log("OCR Text:", ocrText);
 
         // Parse and search Pokémon TCG API
-        const name = ocrText.split('\n')[0]; // Assuming the name is the first line
+        const name = cleanName(ocrText.split('\n')); // Assuming the name is the first line
         const setNumberMatch = ocrText.match(/\d+\/\d+/);
         const setNumber = setNumberMatch ? setNumberMatch[0] : null;
 
@@ -40,7 +41,7 @@ router.post('/api/recognizeCard', upload.single('file'), async (req, res) => {
             console.log("Failed to parse card name or set number.");
             return res.status(400).json({ error: 'Could not parse card name or set number from image.' });
         }
-
+        
         console.log("Parsed Name:", name);
         console.log("Parsed Set Number:", setNumber);
 

--- a/server/routes/recognizeCard.js
+++ b/server/routes/recognizeCard.js
@@ -33,7 +33,7 @@ router.post('/api/recognizeCard', upload.single('file'), async (req, res) => {
         console.log("OCR Text:", ocrText);
 
         // Parse and search Pokémon TCG API
-        const name = cleanName(ocrText.split('\n')); // Assuming the name is the first line
+        const name = await cleanName(ocrText.split('\n')); // Assuming the name is the first line
         const setNumberMatch = ocrText.match(/\d+\/\d+/);
         const setNumber = setNumberMatch ? setNumberMatch[0] : null;
 

--- a/server/routes/recognizeCard.js
+++ b/server/routes/recognizeCard.js
@@ -33,7 +33,7 @@ router.post('/api/recognizeCard', upload.single('file'), async (req, res) => {
         console.log("OCR Text:", ocrText);
 
         // Parse and search Pokémon TCG API
-        const name = await cleanName(ocrText.split('\n')); // Assuming the name is the first line
+        const name = await cleanName(ocrText.split('\n').slice(0,4)); // Assuming the name is the first line
         const setNumberMatch = ocrText.match(/\d+\/\d+/);
         const setNumber = setNumberMatch ? setNumberMatch[0] : null;
 

--- a/server/util/pnames.txt
+++ b/server/util/pnames.txt
@@ -1,0 +1,18506 @@
+aggron
+weedle
+ampharos
+ampharos
+bulbasaur
+dratini
+caterpie
+absol g
+aerodactyl
+absol
+venusaur
+ampharos
+alakazam
+arcanine
+beedrill δ
+azumarill
+blaine's moltres
+aerodactyl
+celebi & venusaur gx
+caterpie
+bastiodon
+arcanine
+altaria
+blastoise
+altaria
+blastoise
+articuno
+blaziken fb
+crobat δ
+lucario
+metapod
+blastoise
+brock's rhydon
+azumarill
+ludicolo
+weedle
+aggron
+dark ampharos
+cherrim
+alolan exeggutor
+kakuna
+tangela
+banette
+venusaur & snivy gx
+snivy
+caterpie
+mew
+dialga
+caterpie
+ampharos
+blaine's arcanine
+clefable
+blaziken
+surskit
+venusaur v
+oddish
+caterpie
+armaldo δ
+dratini
+ariados
+oddish
+deoxys
+snivy
+chansey
+ninetales
+beedrill
+manaphy
+pidgeot
+dragonite δ
+drifblim fb
+ditto
+clefable
+cradily δ
+celebi
+gloom
+masquerain
+dark crobat
+cradily
+weedle
+blaine's charizard
+butterfree
+tangrowth
+morelull
+crawdaunt
+dragonair
+weedle
+gallade
+metapod
+magmar
+deoxys
+blaziken
+metapod
+erika's clefable
+charizard
+bellsprout
+dark alakazam
+venonat
+tangela
+team aqua's cacturne
+pinsir
+weedle
+alakazam
+blastoise
+blaziken
+oddish
+altaria
+bulbasaur
+ho oh
+exeggcute
+shuckle
+tangela
+jirachi
+turtwig
+celebi v
+pikachu
+weedle
+venusaur ex
+blaziken
+turtwig
+alakazam
+garchomp
+chimecho δ
+dark ampharos
+ampharos
+charizard
+alolan sandshrew
+butterfree
+dragonite
+exploud
+latias
+pachirisu
+charmander
+team aqua's crawdaunt
+gyarados
+m venusaur ex
+beautifly
+ivysaur
+chimchar
+weepinbell
+deoxys δ
+gloom
+venomoth
+dialga
+delcatty
+tangrowth
+delcatty
+kakuna
+dark arbok
+azumarill
+dark crobat
+flygon
+pineco
+lugia
+articuno
+dragonair
+espeon δ
+cresselia
+dusknoir
+brock's ninetales
+metagross
+onix
+entei
+charizard
+froslass
+grotle
+flareon
+hoppip
+metapod
+roselia
+manaphy
+vileplume
+lileep
+seedot
+kakuna
+drapion
+deoxys δ
+yanma
+charmander
+ampharos
+hoppip
+togepi
+venusaur
+electivire
+skiploom
+mamoswine
+gloom
+dark electrode
+yanmega
+roselia
+electivire fb
+hitmontop
+gengar
+heatran
+cradily
+flygon
+golem
+kakuna
+tangela
+gardevoir
+flareon δ
+team aqua's kyogre
+gengar
+dragonite
+darkrai
+flygon
+servine
+bellossom
+rayquaza
+erika's venusaur
+yanma
+ariados
+bellossom
+dialga
+jolteon
+breloom
+electabuzz
+charizard
+kricketot
+magmortar
+shuckle
+latios
+heatran
+blissey
+lapras
+tangrowth
+charmeleon
+beedrill
+skiploom
+dark donphan
+vileplume
+beedrill
+raichu
+piplup
+burmy
+paras
+blastoise
+butterfree
+seedot
+weedle
+blastoise δ
+charizard
+dialga
+pachirisu
+tangrowth
+rampardos
+nuzleaf
+camerupt
+bagon
+camerupt
+darkrai
+mew
+celebi
+paras
+scyther
+manaphy
+dark blastoise
+empoleon
+haunter
+dark espeon
+victreebel
+tropius
+regigigas
+gardevoir δ
+nidoking
+bellossom
+ivysaur
+cherubi
+roserade
+bellossom
+torterra
+dark houndoom
+wormadam
+chansey
+scyther
+charizard
+jumpluff
+arcanine
+groudon
+sceptile
+kakuna
+minun
+golem
+kricketune
+dark blastoise
+mewtwo
+gallade
+jumpluff
+pikachu
+vileplume gx
+mothim
+eldegoss v
+team aqua's manectric
+roselia
+jumpluff
+blissey
+starmie
+kabutops
+metagross
+shelgon
+espeon
+erika's dragonair
+pinsir
+scyther
+treecko
+gastly
+giovanni's gyarados
+oddish
+deoxys δ
+pinsir gx
+spinarak
+shiftry
+clefable
+kakuna
+yanma
+kabutops
+luxray
+yanmega
+ninetales
+tangela
+gardevoir
+servine
+hitmonlee
+dark dragonite
+roserade
+karrablast
+pikachu
+delibird
+raticate
+psyduck
+infernape
+plusle
+dark hypno
+rotom
+feraligatr
+porygon z
+crobat
+petilil
+team aqua's sharpedo
+charizard
+garchomp
+dialga g
+tropical wind
+sceptile
+dark feraligatr
+mew δ
+dark charizard
+carnivine
+butterfree
+electrode
+vulpix
+swampert
+mothim
+beedrill
+kyogre
+yanma
+grumpig
+dark gengar
+buneary
+gyarados
+flareon
+entei
+dark dragonite
+giovanni's machamp
+mismagius
+forretress
+salamence
+gloom
+drifloon
+dragonite
+ledyba
+mankey
+gardevoir
+shaymin ex
+flaaffy
+grovyle
+lilligant
+snivy
+ariados
+jolteon δ
+torchic
+exeggcute
+beautifly
+lapras
+cottonee
+yanmega
+dark persian
+combee
+pachirisu
+beedrill
+mothim
+hypno
+gastrodon east sea
+lucario
+paras
+manectric
+tangrowth
+charmander
+clefairy
+claydol
+shelmet
+beedrill
+yanmega
+carnivine
+turtwig
+magikarp
+noctowl
+sewaddle
+delibird
+clefairy
+magmortar
+vaporeon
+tangela
+rapidash
+team aqua's walrein
+alakazam
+arcanine
+paras
+exeggcute
+exeggcute
+charizard δ
+wurmple
+masquerain
+giratina
+tangrowth
+erika's vileplume
+arcanine
+victini
+yanmega break
+machamp
+parasect
+porygon z
+combusken
+chikorita
+alolan exeggutor
+whimsicott
+minun
+servine
+sceptile
+ledyba
+gyarados
+exeggutor
+quagsire
+pansage
+vespiquen
+charmeleon
+parasect
+dark marowak
+arcanine
+vileplume
+deoxys δ
+serperior
+jigglypuff
+buizel
+latias
+exeggcute
+roselia
+accelgor
+phantump
+milotic
+forretress
+onix
+espeon
+team magma's aggron
+sceptile ex
+bastiodon gl
+dark dugtrio
+latias δ
+scyther
+gastrodon west sea
+giovanni's nidoking
+entei
+solrock
+groudon
+greninja
+exeggutor
+combusken
+crawdaunt
+gible
+probopass
+snivy
+cranidos
+dark houndoom
+turtwig
+gyarados
+parasect
+double rainbow energy
+armaldo
+bellsprout
+beedrill
+bellossom
+aggron
+entei
+pansage
+snivy
+scyther
+weepinbell
+incineroar v
+team magma's claydol
+dark raichu
+alolan meowth
+raichu
+rowlet
+kabutops
+blaziken
+butterfree
+serperior
+butterfree
+pidgeot
+simisage
+dark octillery
+detective pikachu
+swadloon
+hitmonchan
+tangela
+riolu
+octillery
+pinsir
+dark golbat
+mew
+roserade
+heracross
+chikorita
+lt. surge's electabuzz
+alakazam
+latios δ
+dark porygon2
+charizard gx
+cacturne
+exeggcute
+sunkern
+ledian
+pikachu
+grovyle
+combusken
+simisage
+rayquaza
+darkrai g
+deoxys δ
+exeggutor
+houndoom
+pinsir
+hitmonchan
+maractus
+murkrow
+silcoon
+kirlia
+ho oh
+salamence
+dusclops
+giovanni's persian
+latios
+giratina
+banette
+articuno
+exeggutor
+gyarados
+m sceptile ex
+seedot
+dugtrio
+wurmple
+serperior
+grotle
+espeon
+trevenant
+butterfree v
+rowlet
+weedle
+rowlet & alolan exeggutor gx
+caterpie
+venusaur ex
+croagunk
+servine
+virizion ex
+treecko
+maractus
+manectric
+floatzel gl
+bayleef
+lapras
+gyarados
+raikou
+yanma
+leavanny
+marowak δ
+beedrill
+torterra
+team magma's groudon
+victini ◇
+lt. surge's fearow
+victreebel
+dewgong
+volbeat
+foongus
+cradily
+beautifly
+politoed
+ho oh
+dark slowking
+gabite
+butterfree vmax
+hitmontop
+claydol
+koga's beedrill
+combee
+dark scizor
+houndoom
+grovyle
+sunflora
+sewaddle
+shieldon
+dark gyarados
+zapdos
+stantler
+durant
+jumpluff
+metapod
+sceptile
+tepig
+nuzleaf
+muk
+cacnea
+jigglypuff
+spiritomb
+mr. mime
+yanma
+sizzlipede
+silcoon
+pupitar
+genesect
+tentacruel
+metagross
+alolan dugtrio
+surskit
+swalot
+jolteon
+tangrowth
+wimpod
+m venusaur ex
+pinsir
+serperior
+sceptile
+luxray
+machamp
+forretress
+shuckle
+flygon δ
+magmar
+sewaddle
+pansage
+alakazam
+ampharos
+espeon
+clefable
+pheromosa & buzzwole gx
+chespin
+aggron
+leafeon
+bulbasaur
+heatran
+palkia g
+ditto
+amoonguss
+magneton
+mew
+tangrowth
+pansage
+forretress
+fennekin
+oshawott
+swampert
+sewaddle
+illumise
+celebi ex
+eevee
+suicune
+rayquaza c
+jirachi
+litten
+alolan exeggutor
+magnezone
+darumaka
+gliscor
+lotad
+psyduck
+dark typhlosion
+centiskorch
+shaymin ◇
+wormadam sandy cloak
+shiftry
+pansage
+koga's ditto
+marill
+vespiquen
+deerling
+ho oh
+crobat
+team magma's houndoom
+masquerain
+cascoon
+dwebble
+yanmega
+karrablast
+gyarados δ
+charmeleon δ
+metagross δ
+rayquaza
+cherubi
+lt. surge's magneton
+charizard ex
+houndoom
+butterfree
+plusle
+ludicolo δ
+torterra lv.x
+mewtwo
+beautifly
+ivysaur
+magneton
+dhelmise v
+sewaddle
+lucario
+heal energy
+dark slowbro
+rotom
+lopunny
+donphan
+beautifly
+electrode
+genesect ex
+hypno
+ampharos
+sceptile
+azumarill
+paras
+ambipom
+dusclops
+flygon
+chikorita
+dartrix
+dark hypno
+caterpie
+ledyba
+ho oh
+team magma's numel
+scyther
+weedle
+heracross
+dark vaporeon
+lapras
+mewtwo
+pokémon fan club
+luvdisc
+ludicolo
+roselia
+exeggutor
+cascoon
+snover
+scyther
+luxray
+infernape lv.x
+rowlet
+lombre
+swadloon
+crustle
+shaymin
+mew
+manaphy
+misty's seadra
+axew
+simisage
+foongus
+vespiquen
+charmander
+moltres
+shiftry
+cherrim
+magneton
+rampardos
+regigigas fb
+tauros
+celebi
+houndoom
+venomoth
+dark steelix
+torkoal
+golisopod
+bill's maintenance
+dark celebi
+slowking
+lickilicky
+sceptile
+team magma's rhydon
+houndoom
+crobat
+burmy plant cloak
+darmanitan
+dark tyranitar
+mewtwo δ
+pikachu
+meganium
+carvanha
+popplio
+chespin
+nincada
+meganium
+mewtwo
+lt. surge's raichu
+cherubi
+grookey
+venusaur ex
+bellsprout
+aggron
+deoxys normal forme
+sewaddle
+cacnea
+slowpoke
+grookey
+yanmega
+victreebel
+jirachi
+salamence
+lugia
+misty's golduck
+ludicolo
+leavanny
+blaziken
+swadloon
+cherrim
+dark machamp
+charizard ex
+metapod
+forretress
+dartrix
+sudowoodo
+jumpluff
+flareon
+mew
+caterpie
+rayquaza δ
+pachirisu
+rhyperior
+metagross
+exeggutor
+froslass gl
+misty's tentacruel
+larvesta
+spinarak
+articuno
+dusknoir
+probopass
+spinarak
+altaria
+axew
+heatmor
+victini
+ludicolo
+venusaur
+team magma's camerupt
+wobbuffet
+fennekin
+m charizard ex
+flareon
+flareon
+azelf
+nidoking
+froakie
+mismagius
+jirachi
+sewaddle
+growlithe
+shroomish
+lileep
+kangaskhan
+team magma's torkoal
+vulpix
+quilladin
+larvitar
+staravia
+burmy sandy cloak
+magcargo
+kakuna
+bellossom
+scramble energy
+manectric
+m venusaur ex
+electrode
+octillery
+dewgong
+amoonguss
+sharpedo
+mewtwo
+weepinbell
+torterra
+parasect
+fletchinder
+kabutops δ
+swadloon
+jumpluff
+pikachu
+dustox
+toxicroak
+abomasnow
+swampert
+simisage
+dwebble
+pineco
+shaymin
+shedinja
+ariados
+gengar
+venusaur
+growlithe
+pichu
+leavanny
+empoleon
+dark magneton
+carnivine
+fennekin
+jumpluff
+shaymin
+staryu
+camerupt
+victreebel
+virizion
+staraptor fb
+charmander
+volcarona
+cresselia
+butterfree
+salamence δ
+slowking
+torchic
+kyogre
+rocket's hitmonchan
+dragonite
+cacturne
+magneton
+sewaddle
+bayleef
+scorbunny
+ninjask
+jolteon
+high pressure system
+hitmontop
+pansage
+decidueye
+wimpod
+chespin
+karrablast
+light arcanine
+kingdra
+lugia
+marowak
+litwick
+reshiram
+rare candy
+moltres
+ampharos δ
+chesnaught
+blissey
+diglett
+yanmega
+armaldo
+xatu
+wailord
+feraligatr δ
+shroomish
+victreebel
+machamp
+misty's gyarados
+zapdos g
+corsola
+empoleon lv.x
+cradily
+meganium
+nidoking
+sylveon
+fraxure
+bidoof
+metapod
+beedrill
+palkia
+poliwrath
+lucario gl
+chimecho
+flareon
+ariados
+scatterbug
+muk
+swadloon
+snorlax gx
+feraligatr
+raichu
+darkrai
+grookey
+ponyta
+dustox
+chespin
+ambipom
+rocket's moltres
+ampharos
+wailord v
+pikachu
+gyarados
+jolteon
+scizor
+swadloon
+leafeon gx
+reshiram gx
+ledian
+caterpie
+mawile
+arbok
+talonflame
+team aqua's spheal
+crustle
+petilil
+nidoqueen
+mudkip
+kyogre ex
+absol
+exploud
+kingdra δ
+rapidash
+boost energy
+minun
+froslass
+arcanine
+drednaw v
+fennekin
+ninetales
+braixen
+leafeon
+weedle
+lilligant
+porygon2
+forretress
+leafeon
+zekrom
+infernape
+sableye
+roselia
+virizion
+raichu
+rocket's scyther
+swampert
+simisage
+smeargle
+kangaskhan
+slugma
+celebi
+snivy
+rhyperior
+flareon
+nidoking
+larvesta
+starmie gx
+rocket's mewtwo
+charmeleon
+heracross
+fraxure
+shelmet
+kingdra
+blastoise
+heracross ex
+leavanny
+mew
+oddish
+ludicolo
+nincada
+groudon ex
+treecko
+glalie
+sobble
+low pressure system
+lucario lv.x
+wartortle
+ninetales
+torkoal
+houndoom
+banette
+tropius
+hitmonlee
+decidueye gx
+lanturn
+shuckle
+squirtle
+mow rotom
+metapod
+exeggcute
+heracross δ
+lucario
+light azumarill
+starmie δ
+ariados
+misdreavus
+petilil
+chespin
+lampent
+scatterbug
+dialga
+banette
+litten
+carnivine
+delcatty
+mightyena
+jigglypuff
+tangrowth
+luxray gl
+butterfree
+chandelure
+shaymin
+pheromosa
+seedot
+breloom
+beedrill
+mareep
+cherrim
+rockruff
+aerodactyl
+wobbuffet
+ivysaur
+nidoqueen
+roselia
+surskit
+xerneas
+buneary
+delphox
+lucario
+magikarp
+charizard
+lumineon
+torkoal
+bronzong
+meowth
+thwackey
+shaymin
+dark slowbro
+leavanny
+buneary
+mr. mime
+seedot
+treecko
+pansear
+snivy
+flareon
+spewpa
+heracross
+magneton
+m heracross ex
+piloswine
+light dragonite
+pansage
+roserade
+wartortle
+gengar
+lickitung
+blaziken
+haxorus
+houndour
+team aqua's sealeo
+bronzong
+servine
+skuntank
+rocket's zapdos
+magikarp
+volcarona
+venusaur
+pidgey
+pidgeot
+hoppip
+cacnea
+drednaw vmax
+arcanine
+poliwrath
+groudon
+chespin
+plusle
+raikou
+maractus
+zapdos
+slowbro
+meganium δ
+buizel
+treecko
+genesect
+heracross
+latias δ
+lilligant
+ninjask
+dustox
+togekiss
+oddish
+kakuna
+kricketot
+feraligatr
+litleo
+entei
+butterfree
+meowth v
+nidoqueen
+togetic
+quilladin
+heatran ex
+celebi
+fennekin
+quilladin
+ninjask
+hoppip
+dwebble
+surskit
+gloom
+pansage
+snubbull
+roserade
+δ rainbow energy
+umbreon
+shedinja
+kricketot
+poliwrath
+jolteon
+grubbin
+porygon2
+lotad
+simisage
+team aqua's crawdaunt
+maractus
+tyranitar δ
+slaking
+cherubi
+charmander
+lunatone
+yanmega
+pidgeot
+swalot
+roserade
+oricorio
+chimchar
+light togetic
+girafarig
+charmander
+jirachi
+glaceon
+blastoise
+pikipek
+carnivine
+charizard
+pyroar
+vileplume
+eevee
+slowking
+hoothoot
+gyarados gx
+lugia
+heracross
+team aqua's walrein
+muk
+dewpider
+crawdaunt
+moltres
+delphox break
+gardevoir
+bronzong
+latios δ
+accelgor
+kyogre
+kricketune
+chatot
+bastiodon
+blastoise
+masquerain
+cacturne
+sabrina's alakazam
+grovyle
+ponyta
+mismagius gl
+tepig
+aerodactyl
+carnivine
+togekiss
+fletchinder
+nuzleaf
+grovyle
+magnezone
+vivillon
+giratina
+serperior
+raichu
+ralts
+sabrina's gengar
+shiftry
+vulpix
+thwackey
+gyarados
+skiddo
+team aqua's mightyena
+salandit
+maractus
+lapras
+kabutops
+entei
+meowth vmax
+omastar δ
+manectric
+charmander δ
+foongus
+salamence
+primeape
+shiftry
+totodile
+litleo
+jumpluff
+sceptile
+mr. briney's compassion
+sentret
+litten
+lombre
+oshawott
+sewaddle
+swellow
+cottonee
+charmeleon
+clefable
+umbreon δ
+rapidash
+shinx
+chimchar
+skiploom
+blaine
+gliscor
+charmeleon
+machamp
+rampardos gl
+braixen
+milotic δ
+dodrio
+rillaboom
+skuntank
+team aqua's kyogre ex
+chesnaught
+pikachu
+roserade
+tropius
+deerling
+karrablast
+paras
+rattata
+weavile g
+arcanine g
+butterfree
+altaria
+luxio
+karrablast
+druddigon
+lapras
+krabby
+shedinja
+gible
+seel
+crustle
+beedrill
+yveltal
+gorebyss
+pansear
+crobat
+tauros
+vileplume
+kricketune
+venusaur
+raichu
+magnezone
+mudkip
+sudowoodo
+shroomish
+ninetales
+litwick
+cherrim
+raikou
+gardevoir v
+dark dragonite
+houndoom
+kabutops
+ditto
+noctowl
+poliwrath
+flareon
+nidoking
+fomantis
+machamp
+dragonair
+ditto
+mawile
+lickitung
+rillaboom
+flygon
+tangela
+ludicolo
+heatran
+drifblim
+parasect
+gengar
+larvesta
+chesnaught
+simisage
+ditto
+shroomish
+remoraid
+nosepass
+mewtwo
+litleo
+simisear
+scatterbug
+exp. share
+shelmet
+gogoat
+meowth δ
+leavanny
+dark vileplume
+amoonguss
+dewgong
+pidgeot δ
+magmortar
+rillaboom
+armaldo ex
+araquanid
+suicune
+spinda
+brock
+mismagius
+pikachu
+feraligatr
+eevee
+swadloon
+ninetales
+dragonite
+leafeon
+kingdra
+charizard
+vaporeon δ
+jumpluff
+carnivine
+lurantis gx
+sunflora
+pikachu
+team aqua's grimer
+venonat
+salandit
+whimsicott
+pikachu
+multi technical machine 01
+petilil
+sceptile
+pidgeot
+night maintenance
+kingler
+magnemite
+ponyta
+squirtle
+salazzle
+staraptor
+hariyama
+altaria
+alolan vulpix
+fearow
+giovanni
+chimchar
+scyther
+delphox
+muk
+vaporeon
+karrablast
+nidoking δ
+suicune
+medicham
+huntail
+jolteon
+gardevoir vmax
+zapdos
+roserade gl
+dark muk
+togedemaru
+wigglytuff
+deerling
+feraligatr
+maractus
+shelmet
+articuno
+breloom
+piplup
+cleffa
+team aqua's sealeo
+scraggy
+ivysaur
+accelgor
+banette
+shiftry
+blipbug
+floatzel
+politoed
+petilil
+azumarill δ
+hatenna
+pinsir
+meganium
+sableye
+charizard
+horsea
+pyroar
+shiinotic
+zoroark
+slaking
+dark raticate
+venusaur
+spewpa
+leafeon
+bibarel
+dugtrio
+manectric
+sawsbuck
+darumaka
+pokémon park
+salazzle
+victini
+rare candy
+surskit
+rapidash
+piplup
+dewpider
+totodile
+slaking
+frosmoth
+wooper
+seedot
+manaphy
+lanturn
+sawsbuck
+girafarig
+beedrill
+erika
+volcarona
+venusaur
+cradily
+torchic
+xerneas ex
+charmander
+pheromosa
+monferno
+ninetales
+foongus
+team aqua's muk
+lugia
+pikachu
+dark weezing
+exeggutor
+raichu δ
+blastoise
+kabutops
+cloyster
+nidoqueen δ
+miracle energy
+articuno
+aerodactyl
+octillery
+shaymin
+chesnaught break
+raichu
+venusaur
+koga
+ditto
+starly
+dialga lv.x
+lilligant
+garchomp
+raichu
+kingdra
+nincada
+cottonee
+magmar
+treecko δ
+first ticket
+team aqua's seviper
+foongus
+leavanny
+moltres ex
+forretress
+octillery
+morelull
+beedrill
+typhlosion
+accelgor
+lunatone
+litwick
+charmeleon
+wobbuffet
+panpour
+moltres
+pachirisu
+shiinotic
+lilligant
+amoonguss
+magneton
+dark sandslash
+vulpix
+skiddo
+relicanth
+turtonator
+luxray
+torterra
+mewtwo
+scizor
+croconaw
+araquanid
+magmortar
+roseanne's research
+super rod
+farfetch'd
+lampent
+tangela
+scyther
+butterfree
+hariyama
+jigglypuff
+tepig
+hattrem
+ninetales
+axew
+metagross
+absol
+ninetales δ
+turtwig
+bruxish
+meganium
+regigigas
+dark ariados
+mewtwo
+masquerain
+tv reporter
+pikachu δ
+celebi
+qwilfish
+turtwig
+galarian perrserker
+rowlet
+fletchinder
+ledian
+butterfree fb
+yveltal ex
+volbeat
+seedot
+tyranitar ex
+palkia lv.x
+treecko
+sabrina
+deoxys
+durant
+typhlosion
+omanyte
+poliwrath
+marshtomp
+dragonite
+cottonee
+vulpix
+here comes team rocket!
+entei ex
+pineco
+ninjask
+volcarona
+honchkrow
+team aqua's sharpedo
+vivillon
+venonat
+team aqua's seviper
+delcatty
+infernape
+cacturne δ
+wigglytuff
+mightyena
+dragonite
+kingdra
+blipbug
+pikachu
+aggron
+chimchar
+virizion
+suicune
+quagsire
+raichu gx
+shining genesect
+snover
+skiddo
+wimpod
+gogoat
+azumarill
+monferno
+chandelure
+alolan marowak
+lt. surge
+dugtrio
+seviper
+moltres
+sceptile
+pelipper δ
+chimchar
+electivire
+hatterene
+dwebble
+bounsweet
+blaine's ninetales
+ninetales
+scatterbug
+feebas
+ninjask
+magmar
+talonflame
+torchic
+zapdos
+dottler
+snorlax
+pansage
+torchic
+venomoth
+cool porygon
+milotic
+rowlet
+venusaur
+shelmet
+arcanine
+nuzleaf
+feraligatr
+lumineon
+scizor
+mamoswine
+rhydon
+turtonator gx
+machamp
+darkrai lv.x
+kyurem
+whimsicott
+rocket's sneak attack
+froakie
+growlithe
+camerupt
+tepig
+ursaring
+magikarp
+combusken
+rowlet
+passimian
+feraligatr
+froakie
+ninetales
+honchkrow
+claydol
+charmander
+shuckle
+team magma's camerupt
+pinsir δ
+rapidash
+deoxys
+palkia
+cinccino
+garchomp ex
+lampent
+sceptile
+gengar
+charizard
+meganium
+latias
+lanturn
+togepi
+chimchar
+litten
+shelmet
+snorunt
+team magma's baltoy
+gardevoir
+pichu bros.
+talonflame break
+deoxys ex
+beedrill
+dark tyranitar
+omastar
+rayquaza δ
+dark magcargo
+illumise
+magmortar
+entei gx
+milotic
+venomoth gx
+vileplume δ
+slaking
+misty
+magmar
+furret
+gogoat
+oranguru
+smeargle
+chimchar
+fearow
+heatran
+rayquaza
+frogadier
+zapdos
+computer error
+ho oh ex
+honchkrow
+azurill
+horsea
+team magma's claydol
+dragonair
+charmeleon
+abomasnow
+team magma's lairon
+steenee
+pinsir
+kabutops
+glalie
+torchic
+salamence
+dialga
+accelgor
+gyarados
+pinsir
+bastiodon
+torracat
+gengar
+orbeetle
+whimsicott
+shuckle gx
+brock's dugtrio
+alolan marowak
+vaporeon
+spewpa
+gossifleur
+slowbro
+zorua
+latios
+dartrix
+glalie
+combusken
+arcanine
+beedrill
+shiftry gx
+charizard ex
+slowking
+alolan sandshrew
+reshiram
+dartrix
+dusclops
+deoxys
+accelgor
+articuno
+chandelure
+elekid
+crustle
+pignite
+entei
+snorlax δ
+beautifly
+dedenne
+bronzong e4
+magneton
+golisopod gx
+pichu
+litleo
+lucario
+shaymin
+voltorb
+dragalge
+croagunk
+moltres
+frogadier
+seviper
+bulbasaur
+vaporeon
+dark omastar
+trevenant ex
+finneon
+metagross
+magcargo
+banette
+omastar break
+infernape
+magmar
+exploud
+glaceon ex
+froslass
+steelix
+fearow δ
+holon's electrode
+numel
+the rocket's trap
+haunter
+palkia
+giovanni's nidoqueen
+reshiram
+articuno
+dragonair
+beedrill
+charizard
+rainbow energy
+venomoth
+camerupt g
+happiny
+togetic δ
+slugma
+fennekin
+petilil
+victini
+wooloo
+decidueye
+chansey
+karrablast
+team magma's mightyena
+team magma's aron
+shiftry
+dark slowking
+bellsprout
+leafeon
+torterra
+cacnea
+dark tyranitar
+virizion
+magmortar
+shelgon
+seadra
+ho oh
+gyarados
+genesect
+decidueye
+numel
+zangoose δ
+charmander
+beautifly
+golduck
+magmortar
+dugtrio
+swampert
+ludicolo
+drapion e4
+vivillon
+greninja
+m charizard ex
+spheal
+phantump
+meganium
+pignite
+dugtrio
+monferno
+snorlax
+feraligatr
+dark persian
+granbull
+heracross
+victini ex
+absol
+skarmory
+tyranitar
+machamp
+alolan sandshrew
+smeargle
+leafeon ex
+mewtwo
+tsareena
+bibarel
+surskit
+zangoose
+horsea
+lumineon
+golem
+combusken
+entei gx
+electrode
+galarian cursola v
+mudkip
+shiftry
+meowth
+pyroar
+vulpix
+magcargo
+ninetales
+skiddo
+raichu
+cleffa
+wailord
+umbreon
+hitmonlee
+pyroar break
+magmortar
+clauncher
+kingdra gx
+masquerain
+buzzwole
+emboar
+charizard ex
+ninetales
+lycanroc gx
+minccino
+dark alakazam
+skiddo
+trevenant
+fennekin
+omastar
+delibird
+victini
+vulpix
+morpeko
+grumpig
+brock's golem
+cleffa
+raichu
+houndoom
+espeon ★
+electivire
+solrock
+jolteon
+mesprit
+tauros
+seadra
+phione
+magcargo
+magneton
+giovanni's pinsir
+carnivine
+growlithe
+gossifleur
+ho oh ex
+blaziken
+bellossom δ
+victini ex
+weepinbell
+numel
+charmander
+foongus
+umbreon
+breloom
+charizard g
+pansear
+skiddo
+hariyama
+vaporeon
+voltorb
+sealeo
+squirtle
+honedge
+alcremie v
+bounsweet
+alolan sandslash
+victreebel
+infernape
+slowking
+marshtomp
+dark ursaring
+frillish
+gengar
+team magma's rhydon
+white kyurem
+holon's magneton
+grovyle δ
+luvdisc
+hypno
+kingdra
+blissey
+espeon e4
+team rocket's meowth
+metagross
+celebi ◇
+skarmory
+politoed
+magcargo
+eevee
+camerupt
+walrein
+electabuzz
+piplup
+sudowoodo
+reshiram ex
+relicanth
+abomasnow
+wingull
+slaking
+dark arbok
+zapdos
+pelipper
+volbeat
+victini
+xurkitree
+team magma's zangoose
+magikarp
+jellicent
+hypno
+mime jr.
+machamp
+flareon
+pelipper
+eldegoss
+steelix
+victreebel
+electrode
+koga's arbok
+team magma's lairon
+staryu
+m charizard ex
+bronzong
+clefable
+raichu
+ninetales
+camerupt
+rotom
+servine
+walrein
+torchic
+vileplume
+bellossom
+pinsir
+alolan vulpix
+ampharos
+riolu
+relicanth
+simisear
+charizard & braixen gx
+dugtrio
+lugia
+torkoal
+braixen
+umbreon ★
+camerupt
+snover
+zangoose
+galarian ponyta
+squirtle
+charmeleon
+brock's onix
+hypno
+magikarp
+lopunny
+mismagius
+amoonguss
+arcanine
+lapras
+probopass
+gogoat
+phanpy
+blaziken
+tepig
+hypno
+lilligant
+slugma
+volcanion
+pansage
+unown [a]
+furret
+grubbin
+steenee
+gogoat
+typhlosion δ
+suicune
+light dragonair
+alcremie vmax
+electrode
+poochyena
+vaporeon
+staryu
+pikachu
+illumise
+treecko
+ponyta
+drapion
+light lanturn
+solrock
+dusclops
+volcanion ex
+zapdos
+togetic
+abomasnow
+dark blastoise
+starmie
+deerling
+wooper
+team magma's aggron
+ursaring
+rayquaza
+victini
+turtwig
+tentacruel
+trevenant
+torkoal
+furret
+gyarados
+vibrava
+gyarados
+magcargo
+ledian
+charizard gx
+zygarde
+kabutops
+manectric
+tangela
+claydol
+seviper
+pansear
+dialga
+butterfree
+poliwrath
+machop
+starmie
+binacle
+glameow
+brock's rhyhorn
+litwick
+emboar
+ninetales ex
+torkoal
+cherrim
+larvesta
+chimecho
+electabuzz
+meowth
+victreebel
+electabuzz
+ledian
+arcanine
+pikachu
+pansear
+mightyena
+cyndaquil
+camerupt
+golem
+combusken
+cleffa
+ninetales break
+delphox
+wartortle
+heat rotom
+dhelmise
+pidove
+pikachu
+tsareena
+rillaboom v
+luvdisc
+gallade e4
+wigglytuff
+magneton
+pidgeotto
+pansage
+regice
+vulpix
+blaziken
+typhlosion
+alolan vulpix
+rayquaza
+kricketune
+tepig
+grovyle
+magby
+ninetales
+volcarona
+rillaboom v
+lampent
+salandit
+lapras
+bagon
+pignite
+cacnea
+raichu
+typhlosion
+feraligatr
+ho oh gx
+dwebble
+growlithe
+buizel
+aerodactyl
+barbaracle
+litten
+inkay
+darkrai
+fomantis
+team aqua's cacnea
+simisear
+latias
+litleo
+simisear
+wailmer
+team magma's groudon ex
+lapras
+latias δ
+combusken
+smoochum
+machoke
+rapidash
+electrode
+togetic
+omastar
+mightyena δ
+arcanine
+tangrowth
+dark charizard
+tirtouga
+slurpuff
+lapras
+alolan ninetales gx
+sabrina's abra
+rillaboom vmax
+axew
+rotom
+heatmor
+grumpig
+emboar ex
+orbeetle v
+spinda
+quilava
+meganium
+blaziken
+sawsbuck
+kingler
+golduck
+pansear
+elekid
+alomomola
+brock's sandslash
+wobbuffet
+drifblim
+clefable
+celebi ex
+tyranitar
+mantine
+wimpod
+sableye
+arcanine
+moltres
+quagsire
+primeape
+light ledian
+regigigas
+kyurem ex
+ekans
+dark dragonite
+grubbin
+latios δ
+hitmonchan
+gogoat
+cinderace v
+dugtrio
+electrode
+drapion
+pignite
+larvesta
+granbull
+reshiram
+floatzel
+koga's muk
+golem
+pansear
+porygon2
+misdreavus
+pyroar
+eldegoss v
+camerupt
+wailord
+spiritomb
+magikarp
+pignite
+golisopod
+ponyta
+voltorb
+lanturn
+chimecho
+fennekin
+heatmor
+breloom
+simisear
+igglybuff
+cacturne
+bronzong
+charmeleon
+tentacool
+flareon
+roserade
+magcargo
+pelipper
+sceptile gx
+shuppet
+tropical wind
+torracat
+kingler
+carracosta
+chansey
+lapras
+brock's zubat
+heatmor
+dodrio
+lurantis
+gastrodon east sea
+team aqua's poochyena
+pawniard
+claydol
+lapras
+glaceon
+nidoqueen
+psyduck
+seaking
+manectric ex
+totodile
+typhlosion
+persian
+typhlosion
+arbok δ
+torkoal v
+blastoise
+rotom
+poliwag
+articuno
+shuckle
+braixen
+dustox
+drifblim
+uxie
+steelix
+team aqua's carvanha
+skarmory
+hitmonlee
+yanmega
+m manectric ex
+magneton
+torkoal
+shiftry
+pichu
+erika's clefairy
+donphan
+espeon
+crawdaunt g
+kartana
+lunatone
+raikou
+electrode
+ducklett
+psyduck
+larvesta
+dewgong
+shellos
+litten
+kangaskhan
+emboar
+wurmple
+feebas
+inkay
+ekans
+exeggutor
+light machamp
+slugma
+emboar
+pichu
+latios
+arcanine
+empoleon
+salazzle
+machamp
+yanma
+jolteon
+charizard v
+electrode
+orbeetle vmax
+electrode
+gorebyss
+tropius
+squirtle
+dialga
+darumaka
+rapidash
+dustox
+croconaw
+houndoom ex
+torchic
+magcargo
+tympole
+m houndoom ex
+treecko
+reshiram & charizard gx
+delphox
+alakazam ex
+applin
+inteleon v
+wobbuffet
+kingler δ
+dewott
+huntail
+moltres
+porygon z g
+charizard ex
+quagsire
+gyarados gx
+cloyster
+piloswine
+torkoal
+machamp
+mawile
+larvesta
+virizion
+magneton
+golduck
+incineroar
+mr. mime
+bisharp
+rain castform
+tentacruel
+feraligatr
+dratini
+cloyster δ
+palkia gx
+lapras
+milotic
+sandslash
+light piloswine
+darumaka
+gastrodon west sea
+koga's pidgeotto
+solgaleo gx
+bergmite
+machamp
+jynx
+ducklett
+tyranitar
+simisear
+bounsweet
+team magma's poochyena
+dark dugtrio
+panpour
+gastrodon
+victini v
+moltres
+dhelmise
+heatmor
+metal energy
+kyurem ex
+poliwhirl
+meganium
+psyduck
+darmanitan
+reshiram
+heatmor
+wooper
+grovyle
+golduck
+charizard vmax
+pansear
+dodrio
+zarude v
+floatzel
+torchic
+larvesta
+arbok
+mawile
+swinub
+lt. surge's jolteon
+avalugg
+skarmory
+magby
+palkia
+dark golbat
+team aqua's corphish
+empoleon
+froakie
+malamar
+dewgong
+articuno
+turtonator
+simipour
+golem e4
+steenee
+darumaka
+plusle
+erika's victreebel
+combusken
+slugma
+tropius
+skarmory
+articuno ex
+nosepass
+mewtwo δ
+hitmontop
+zapdos
+dusknoir
+armaldo
+emolga
+heatmor
+umbreon
+cleffa
+lunala gx
+politoed
+golem
+darumaka
+m manectric ex
+politoed
+wurmple
+espeon
+volcarona
+torracat
+ampharos ex
+loudred
+ponyta
+entei
+abomasnow
+dewgong δ
+magmar
+lucario v
+toxtricity v
+magmortar
+kecleon
+dodrio
+tropius
+houndoom v
+gligar δ
+victreebel
+gengar
+golduck
+pansear
+tynamo
+volcarona
+zacian v
+growlithe
+unown [g]
+nosepass
+azelf
+magmortar
+muk
+flareon
+alolan sandshrew
+mudkip
+quagsire
+sabrina's gengar
+torchic
+froakie
+darmanitan
+pelipper
+chesnaught ex
+torkoal
+salandit
+magmar
+tsareena
+sandslash δ
+staryu
+fletchinder
+incineroar gx
+poliwrath
+swinub
+grumpig
+poliwrath
+marshtomp
+shinx
+raichu
+koffing
+smoochum
+ariados
+delibird
+dugtrio
+omastar
+pidgeotto
+giratina
+m ampharos ex
+latias
+nidoqueen
+dratini
+piloswine
+charmander
+electrike
+m alakazam ex
+simisear
+silcoon
+poipole
+beedrill
+meganium
+basculin
+anorith
+zapdos
+lt. surge's electabuzz
+masquerain
+gengar
+tympole
+reshiram ex
+vespiquen
+minun
+incineroar
+alolan sandslash
+tyranitar
+mightyena
+heracross e4
+pachirisu
+magcargo
+spheal
+flareon
+pichu
+sabrina's golduck
+_____'s pikachu
+golduck break
+delphox ex
+pinsir
+raichu
+farfetch'd
+salazzle
+sealeo
+carvanha
+blastoise ex
+corsola
+torchic
+farfetch'd
+oricorio
+palpitoad
+whiscash
+sneasel
+mew
+jynx δ
+zamazenta v
+dusknoir fb
+rapidash
+oshawott
+glaceon
+piloswine
+weezing
+metang
+medicham
+grumpig
+bastiodon
+charmeleon
+beautifly
+sudowoodo
+zygarde
+raichu
+darumaka
+combusken
+koffing
+vileplume
+team aqua's mightyena
+sunflora
+politoed
+vanillite
+dhelmise
+victini
+mismagius
+eelektrik
+butterfree
+palpitoad
+latios
+heracross
+hippowdon
+squirtle
+vileplume
+manectric
+arcanine
+applin
+donphan
+blastoise ex
+minun
+cascoon
+psyduck
+totodile
+magikarp
+ho oh
+gyarados
+team aqua's electrike
+rayquaza δ
+magikarp
+joltik
+simisear
+honedge
+pidgeot
+unown [h]
+lt. surge's raichu
+ninetales
+bellossom
+torchic
+mamoswine
+flaaffy
+frogadier
+giratina
+ursaring
+mewtwo lv.x
+misty's cloyster
+raticate
+sharpedo
+slowpoke
+mawile
+typhlosion
+forretress
+xatu
+wartortle
+vanillish
+woobat
+mamoswine
+charizard
+jynx
+fearow
+combusken
+alolan sandslash
+zoroark
+talonflame
+darumaka
+weezing
+seismitoad
+omastar
+growlithe
+blaziken
+empoleon fb
+espeon
+zapdos
+glaceon
+chimecho
+ninetales
+croconaw
+pelipper δ
+turtonator
+golduck
+team magma's mightyena
+flying pikachu
+zapdos
+feebas
+elekid
+ledian δ
+luxio
+mewtwo
+flapple
+eelektross
+qwilfish
+hippowdon
+greninja ex
+sharpedo
+snorlax
+gyarados
+darmanitan
+galvantula
+m blastoise ex
+salazzle gx
+tepig
+sandslash
+sceptile
+hypno
+greninja gx
+snubbull
+blaine's charmeleon
+rockruff
+jynx
+torchic
+rotom
+cascoon
+magmar
+mudsdale
+hariyama
+seismitoad
+whismur
+unown [w]
+dark gyarados
+tropical tidal wave
+reshiram
+hippowdon
+slowpoke
+starmie
+pikachu
+cradily
+jolteon
+gyarados
+dewott
+weavile
+team aqua's lanturn
+mothim
+remoraid
+mr. mime
+thundurus ex
+riolu
+raikou
+walrein
+machamp
+m blastoise ex
+jynx
+ludicolo
+drampa
+combusken
+buizel
+sudowoodo
+natu
+blastoise
+slowking
+alolan vulpix
+luxray
+blaine's dodrio
+lickitung δ
+bronzong
+rhyperior lv.x
+regice
+lycanroc
+hypno
+forretress
+flareon
+vanillite
+slowbro
+infernape
+graveler
+donphan
+articuno
+magmortar
+dark hypno
+ampharos
+wailord
+seaking
+team aqua's carvanha
+lapras
+oshawott
+drifloon
+lucario
+poliwag
+unown
+wailmer
+blaziken
+unown [x]
+misty's goldeen
+flareon
+pignite
+swampert
+sceptile
+haunter
+team aqua's manectric
+drilbur
+pichu
+seismitoad ex
+arbok
+tyrogue
+dustox
+yanma
+venomoth
+lopunny
+pikachu
+camerupt ex
+dunsparce
+panpour
+pidgeot
+kangaskhan
+feraligatr
+cherrim
+milotic
+gyarados g
+vanilluxe
+blastoise ex
+darmanitan
+rhydon
+crawdaunt
+shiftry
+fennekin
+magby
+raikou
+samurott
+appletun
+clauncher
+scorbunny
+emboar
+murkrow
+jirachi
+kingler
+sceptile
+jolteon
+drifblim
+snow cloud castform
+slowbro
+vanillish
+numel
+granbull
+regirock
+natu
+rain castform
+entei
+graveler
+nincada
+electrode
+cubchoo
+braixen
+pikachu
+mewtwo gx
+articuno
+crobat
+ninetales
+arcanine
+ivysaur
+qwilfish
+polteageist v
+suicune
+kabutops
+magnezone ex
+golduck
+poliwhirl
+dark machamp
+milotic
+frillish
+horsea
+regigigas lv.x
+mew
+floatzel
+skarmory
+steelix
+mantine δ
+dunsparce
+slowking
+delcatty
+dragonair
+hitmontop
+vulpix
+infernape
+slugma
+piplup
+piplup
+jolteon
+helioptile
+wailord
+blaziken gx
+sharpedo
+weezing
+tirtouga
+rockruff
+turtonator
+psyduck
+rolycoly
+oshawott
+team aqua's mightyena
+simipour
+cloyster
+rowlet
+serperior
+mamoswine
+gloom
+team aqua's sharpedo
+machamp
+venusaur
+nidoking
+blaine's rapidash
+sableye
+golbat
+m blastoise ex
+lotad
+lugia
+mr. mime
+dark arbok
+heatran
+furret
+umbreon
+dewott
+bayleef
+exeggutor
+misty's poliwrath
+dark magneton
+uxie
+slowking
+palkia
+heatran lv.x
+leafeon
+vanilluxe
+kricketune
+grapploct v
+scorbunny
+buzzwole
+medicham
+nidoqueen
+clawitzer
+team aqua's sealeo
+jellicent
+litten
+seviper
+lombre
+octillery
+alolan vulpix
+poliwag
+gastly
+illumise
+charmeleon
+starmie δ
+carracosta
+ninjask
+murkrow
+shellder
+beartic
+electabuzz
+helioptile
+buizel
+victreebel
+shellder
+exploud
+deoxys attack forme
+vaporeon
+poliwrath
+torkoal
+ariados
+sneasel
+swirlix
+pikachu & zekrom gx
+snorunt
+suicune
+dark ariados
+magcargo
+houndoom
+registeel
+volcanion
+piplup
+spoink
+quagsire δ
+pidgeot
+surfing pikachu
+larvesta
+spiritomb
+magneton
+pichu
+grovyle
+rapidash
+tympole
+goldeen
+grumpig
+shellder
+phione
+mamoswine gl
+darkrai
+starmie
+jynx
+baltoy
+purrloin
+swampert
+camerupt
+flapple
+clauncher
+psyduck
+prinplup
+magneton
+mew
+ninetales
+relicanth
+basculin
+beldum
+seadra
+jolteon
+brock's graveler
+pansear
+xatu
+team magma's zangoose
+luxray
+lairon
+snow cloud castform
+flaaffy
+grumpig
+dark dragonair
+dewott
+poliwhirl
+cloyster
+amaura
+glalie
+primeape
+seaking
+slowbro ex
+golduck
+cloyster
+aipom
+pidgeot
+cubchoo
+corphish
+clawitzer
+smoochum
+mesprit
+basculin
+electrode
+staryu
+oricorio
+relicanth
+chansey
+farfetch'd
+litten
+heatran gx
+brock's primeape
+vaporeon
+deoxys defense forme
+lickilicky
+palpitoad
+blissey
+honchkrow
+azumarill
+mr. mime e4
+glalie
+vanillite
+alolan ninetales
+zorua
+geodude
+kyogre ex
+roserade
+shellder
+kirlia
+wishiwashi
+porygon
+floatzel
+team magma's baltoy
+seadra δ
+pidgeot
+minun
+scraggy
+ekans
+simisear
+misty's tentacool
+emboar
+metang
+wobbuffet
+volcarona gx
+steelix
+cryogonal
+lombre
+weezing
+primeape
+popplio
+plusle
+ludicolo
+combee
+raboot
+munchlax
+talonflame v
+heliolisk
+magnezone
+helioptile
+sunny castform
+snorlax
+golbat
+alolan geodude
+graveler
+golbat
+marill
+shiftry
+arcanine
+ninetales v
+baltoy
+kadabra
+houndour
+aqua diffuser
+shuppet
+empoleon
+bronzong
+charmeleon δ
+dark slowbro
+scyther
+haunter
+team magma's claydol
+litleo
+mewtwo
+pinsir
+arbok
+ducklett
+rocket's snorlax
+gyarados
+lickilicky c
+vaporeon
+beartic
+litten
+coalossal
+dark croconaw
+trapinch
+golduck
+alolan geodude
+lurantis
+victini
+heliolisk
+golduck
+poliwrath
+vanillite
+palkia
+greninja
+ludicolo
+guzzlord
+carvanha
+azelf
+kakuna
+butterfree
+growlithe
+raboot
+magma pointer
+wobbuffet
+krabby
+dark dragonair
+mudkip
+m slowbro ex
+horsea
+prinplup
+staryu
+poliwrath
+umbreon
+sableye
+piplup
+tangrowth
+aurorus
+bellossom
+graveler
+stantler
+articuno gx
+combusken
+zangoose
+chimecho
+sunny castform
+noctowl
+klang
+vespiquen
+claydol
+linoone
+deoxys speed forme
+gothita
+banette
+gyarados
+crawdaunt
+slowking
+corsola
+clawitzer break
+bronzor
+grotle
+snorlax
+samurott
+swellow
+salamence
+haunter
+tropius δ
+sharpedo
+lombre
+kabutops
+ariados
+aron
+galarian darmanitan
+nidoking
+omastar
+dark vileplume
+cloyster
+vanillish
+seismitoad
+samurott
+phione
+dusknoir
+porygon2
+duskull
+metang
+clauncher
+kyurem
+marshtomp
+kricketune
+phione
+tsareena
+golbat
+torracat
+charmeleon
+blissey
+shellder
+wailmer
+team magma's houndoom
+bayleef
+lotad
+scyther
+kakuna
+magikarp
+brock's sandslash
+golem
+vanillish
+voltorb
+unown [h]
+sharpedo
+staryu
+luvdisc
+typhlosion
+flygon
+croconaw
+krookodile ex
+loudred
+zubat
+garbodor
+lucario c
+starmie
+feebas
+marill
+sunflora
+banette
+swanna
+kabuto
+alomomola
+charmeleon
+arcanine
+ditto
+tangela
+magnemite
+anorith
+hydreigon
+oshawott
+kangaskhan
+tropius
+manaphy
+miltank
+larvesta
+kyurem ex
+munna
+vibrava δ
+solosis
+bergmite
+dusclops
+golett
+samurott
+weezing
+golem
+team aqua admin
+pyroar
+shaymin
+bergmite
+dark exeggutor
+machoke
+anorith
+seadra
+raichu
+alolan graveler
+dark weezing
+horsea
+vanilluxe
+muk
+nidoqueen
+empoleon
+axew
+galarian zigzagoon
+litwick
+drifblim
+clawitzer
+pachirisu
+vaporeon
+tyrogue
+grovyle
+reshiram
+cascoon
+staryu
+sabrina's venomoth
+cinderace
+seviper
+mudkip
+togepi
+hitmonchan
+scizor
+magnemite
+golbat
+dewott
+golurk
+gyarados ex
+cleffa
+anorith
+prinplup
+graveler
+skuntank
+frillish
+volcarona
+galarian linoone
+beldum
+kingdra
+wailord
+metang
+delibird
+cloyster
+charmeleon
+turtonator
+lairon
+skitty
+dusknoir
+manectric
+cubchoo
+swampert
+tropical wind
+moltres
+dratini
+forretress
+wailord
+mantine
+xatu
+magneton
+pikachu
+magmar
+onix gx
+porygon z
+cinderace
+litwick
+zekrom
+manaphy
+brock's vulpix
+milotic
+duosion
+rapidash
+dark flaaffy
+seel
+pyroar
+lunatone
+bayleef
+gastly
+deoxys
+dewgong
+dark charmeleon
+dark flaaffy
+blaine's growlithe
+plusle
+xatu δ
+keldeo
+donphan
+mareep
+mudkip
+magikarp
+cacturne
+virizion gx
+raichu gl
+blastoise & piplup gx
+purugly
+castform
+pinsir
+amaura
+starmie
+electrode
+politoed
+gyarados
+kecleon
+avalugg
+buizel
+vanilluxe
+hitmonlee
+lapras
+torkoal
+aipom
+alolan golem
+gulpin
+tyrogue
+houndoom
+unown [s]
+azumarill
+panpour
+team magma's houndour
+musharna
+team aqua grunt
+vanillite
+mawile
+clefairy
+marshtomp
+charmeleon
+toxicroak ex
+marshtomp
+erika's bellsprout
+snorlax
+rhyperior e4
+graveler
+magneton
+fletchinder
+scizor
+graveler
+minun
+simipour
+alomomola
+weezing
+smeargle
+lampent
+magnezone
+ditto
+electrode
+ninetales
+blaine's kangaskhan
+delibird
+arbok
+lunatone
+jellicent
+volcanion ◇
+swampert
+dratini
+cubone
+kingler
+aerodactyl
+mantine
+avalugg
+raichu
+lapras gx
+bidoof
+magmortar
+shining volcanion
+donphan
+bayleef
+vikavolt
+magmar
+bayleef δ
+hoopa ex
+samurott
+floatzel
+beldum
+alolan vulpix
+lickilicky
+galarian obstagoon
+cubchoo
+m gyarados ex
+skiddo
+drowzee
+dark dragonair
+aurorus
+nidoking
+snorlax
+dewgong
+weavile
+reuniclus
+regice
+empoleon
+staraptor
+champions festival
+noctowl
+dark golbat
+jolteon
+magikarp
+poliwrath
+dark forretress
+ivysaur
+raichu
+flaaffy
+groudon
+corsola
+gallade ex
+zangoose
+vaporeon ex
+cinderace
+oshawott
+skarmory
+voltorb
+team magma's lairon
+lairon
+remoraid
+tropical tidal wave
+alakazam
+machamp ex
+ampharos
+ditto
+swampert
+dewott
+magmar
+steelix
+vanillish
+blaine's magmar
+gyarados
+steelix
+sigilyph
+jynx
+remoraid
+tympole
+torterra
+typhlosion
+gliscor
+chandelure
+magcargo
+pikachu
+dunsparce
+luvdisc
+mr. mime
+psyduck
+beldum
+grovyle
+articuno
+incineroar
+absol
+nidorino
+pikachu
+chinchou
+zapdos
+scraggy
+combusken
+snover
+wormadam plant cloak
+croconaw
+sizzlipede
+minun
+azumarill
+palkia
+duraludon
+dewpider
+lapras
+numel
+glaceon
+medicham
+wigglytuff
+scizor
+ludicolo
+team aqua's great ball
+cryogonal
+ursaring
+championship arena
+dark golduck
+snorlax
+dark electrode
+beartic
+dragonair
+nidoqueen
+electrode
+raticate
+espurr
+wishiwashi
+venusaur ex
+elekid
+marshtomp
+crobat
+combusken
+castform
+oshawott
+gogoat
+machoke
+litwick
+clefairy
+staryu
+erika's bulbasaur
+heatran
+team magma's mightyena
+dark haunter
+mareep
+scizor
+m gallade ex
+talonflame
+aerodactyl δ
+clefable
+wailord ex
+brock's geodude
+flaaffy
+nidoqueen
+ninetales
+tyranitar
+sizzlipede
+marill
+grovyle
+vanilluxe
+gengar ex
+purrloin
+combusken
+manectric
+beartic
+misdreavus
+gligar
+meowstic
+weezing
+omastar
+pikachu
+shaymin
+exeggcute
+dewott
+tangrowth
+salandit
+milotic c
+clefairy
+panpour
+dark flareon
+shinx
+bunnelby
+arbok
+centiskorch v
+camerupt
+ivysaur
+tympole
+sableye
+mimikyu
+lotad
+team aqua's secret base
+raichu gx
+lanturn
+raichu
+corsola
+croconaw
+dragonite gx
+celebi
+vaporeon
+poliwhirl
+diglett
+axew
+ditto
+flaaffy
+plusle
+glalie
+dodrio
+meditite
+tapu bulu
+jirachi
+rayquaza
+palpitoad
+basculin
+machoke
+wooper
+team magma's rhyhorn
+dark omanyte
+entei
+cryogonal
+araquanid
+wormadam sandy cloak
+arcanine
+lanturn
+corsola
+toxicroak
+entei
+erika's clefairy
+fletchinder
+azurill
+croconaw δ
+poliwhirl
+vaporeon
+pachirisu
+haunter
+copperajah v
+venomoth
+voltorb
+solosis
+suicune
+tapu koko
+venusaur
+espeon
+kirlia
+centiskorch vmax
+plusle
+dark gyarados
+dialga lv.x
+starmie
+dragonair δ
+gulpin
+vespiquen
+golduck
+chimecho δ
+seismitoad
+marowak
+scyther
+pichu
+metang
+lombre
+barboach
+porygon
+liepard
+tyranitar
+bulbasaur
+magcargo
+samurott
+kyogre
+kyurem
+shinx
+brock's golbat
+ninetales
+ampharos
+electrike
+ninjask
+umbreon
+suicune
+heracross
+electabuzz
+raichu
+articuno
+lairon
+moltres
+pidgeot
+team magma admin
+smeargle
+litwick
+talonflame
+magby
+shellos
+frillish
+azumarill
+nuzleaf
+lampent
+skrelp
+moltres
+centiskorch
+erika's ivysaur
+charizard ex
+claydol
+wingull
+simipour
+swalot
+unown [p]
+magnemite
+magmar
+jellicent
+samurott
+joltik
+pikachu
+pupitar
+vespiquen e4
+corsola
+ludicolo
+palpitoad
+snivy
+tyranitar
+scraggy
+clefable
+wishiwashi gx
+exeggutor
+abomasnow
+torterra
+weavile
+emolga
+ducklett
+igglybuff
+haunter
+raticate
+geodude
+corsola
+igglybuff
+dratini
+thundurus ex
+giovanni's machoke
+octillery
+galarian mr. mime
+salandit
+quagsire
+zangoose
+moltres ex
+duosion
+lombre
+shellder
+claydol
+vespiquen
+flaaffy
+vibrava
+dark gloom
+blitzle
+galarian darmanitan v
+electabuzz
+celesteela
+roselia
+giratina lv.x
+cubone
+fletchling
+dark pupitar
+morpeko
+starmie break
+octillery
+seadra
+dark houndoom
+zapdos
+team magma grunt
+kabuto
+palkia ex
+ivysaur
+chandelure
+rampardos
+tapu koko
+pidgeotto
+sandslash
+victreebel
+cacturne
+skuntank
+lopunny
+brock's graveler
+beedrill
+slowbro
+lairon
+vanillite
+furret
+kakuna
+swanna
+seel
+slaking
+parasect
+kyurem
+electrode
+jigglypuff
+kabutops
+tropical beach
+bibarel
+luxio
+swellow
+gliscor
+heatmor
+electabuzz δ
+cloyster
+combusken
+snorlax
+electrike
+salazzle
+joltik
+team magma's great ball
+graveler
+zekrom
+shaymin lv.x
+pupitar
+delcatty
+combusken
+kartana
+glaceon gx
+giovanni's meowth
+baltoy
+froakie
+m gengar ex
+dark magcargo
+cyndaquil
+vaporeon
+galarian darmanitan vmax
+sealeo
+mr. mime
+wailmer
+magikarp
+mesprit
+manaphy ex
+mareanie
+dark golduck
+ditto
+wormadam trash cloak
+salazzle
+vaporeon
+wobbuffet
+bayleef
+toxicroak g
+zebstrika
+mareep
+hitmontop
+crobat
+alolan raichu
+masquerain
+magneton
+dark quilava
+magneton
+regirock
+seadra
+rhydon
+scrafty
+tapu koko
+croconaw
+vileplume
+furfrou
+dodrio
+reuniclus
+whiscash
+glalie ex
+exeggutor
+vileplume
+jolteon ex
+panpour
+ducklett
+blastoise ex
+exeggutor
+maractus
+galvantula
+articuno ex
+mantine
+jigglypuff
+cubchoo
+haunter
+jolteon ex
+luxio
+frogadier
+furfrou
+croconaw
+slowpoke & psyduck gx
+cyndaquil
+simipour
+alomomola
+volbeat
+seadra
+ditto
+nidoran ♂
+electrike
+wynaut
+alolan geodude
+marowak
+raikou
+dark jolteon
+giovanni's nidorina
+victory cup
+zacian
+luxio
+golem
+pelipper
+manectric
+wartortle
+regigigas
+flaaffy δ
+metapod
+wobbuffet
+beartic
+wailord
+glalie
+team magma's secret base
+trubbish
+bronzong g
+lickitung
+electivire
+farfetch'd
+whiscash
+emolga
+donphan
+blacephalon
+zapdos ex
+arcanine
+flygon
+magnezone
+togetic
+meowth
+xatu
+ralts
+machoke
+flaaffy
+kyurem ex
+dark magneton
+cinderace v
+nidoran ♀
+breloom
+metang
+tangela
+wigglytuff gx
+alolan geodude
+golurk
+m glalie ex
+tepig
+golett
+sneasel
+krabby
+vanillish
+unown [j]
+dewgong
+binacle
+walrein
+marshtomp
+budew
+ambipom
+larvitar
+parasect
+seadra
+umbreon
+gyarados
+brock's lickitung
+delibird
+dark wigglytuff
+gloom
+weezing
+slowbro
+houndoom
+sudowoodo
+tympole
+poliwrath
+xerneas
+swanna
+galarian mr. rime
+granbull
+wigglytuff
+galvantula
+piloswine
+charmeleon
+tynamo
+ampharos gx
+budew
+quilava
+clamperl
+heracross
+golurk
+oshawott
+butterfree
+regice
+bruxish
+alolan graveler
+fearow
+dark kadabra
+pikachu
+typhlosion
+keldeo ex
+popplio
+squirtle
+alomomola
+plusle
+tapu bulu gx
+erika's dratini
+greninja
+nidorino
+alolan graveler
+mr. mime
+grovyle
+donphan
+lanturn
+larvitar
+tyranitar ex
+cinderace vmax
+magnemite
+toxicroak g
+piplup
+luxray
+binacle
+zapdos
+misdreavus
+gloom
+breloom
+horsea δ
+toxicroak
+tentacruel
+pikachu
+houndoom
+yanmega e4
+hawlucha
+flareon
+lapras
+granbull
+unown [a]
+zamazenta
+cacturne
+altaria
+ditto
+tauros
+frillish
+alakazam
+victory cup
+chewtle
+wash rotom
+unown
+shelgon
+miltank
+baltoy
+suicune
+weavile
+gulpin
+helioptile
+krabby
+medicham
+giovanni's nidorino
+corphish
+nidorina
+kirlia
+exeggutor δ
+inkay
+fearow
+seaking
+double aqua energy
+plusle
+dusclops
+ducklett
+nuzleaf
+tentacruel
+delcatty
+mankey
+primeape
+dark pupitar
+minun
+abra
+crushing hammer
+palpitoad
+thundurus
+cacnea
+vaporeon
+feebas
+floatzel
+jellicent
+typhlosion
+minun
+moltres & zapdos & articuno gx
+nosepass
+feebas
+kirlia
+carnivine g
+magnemite
+manectric
+raichu
+golbat
+regigigas
+alakazam e4
+forretress
+nidorina
+seismitoad
+vibrava
+flaaffy
+yveltal
+weezing
+victory cup
+swalot
+metapod
+malamar
+absol
+prinplup
+poké ball
+alolan golem gx
+koga's golbat
+parasect
+gloom δ
+roserade c
+dragonair δ
+psyduck
+blitzle
+brionne
+shuppet
+machop
+woobat
+pupitar
+dark machoke
+m tyranitar ex
+decidueye
+zubat
+blitzle
+alomomola
+wailmer
+hypno
+growlithe
+dark dragonair
+carnivine
+manectric
+wartortle
+tapu koko gx
+grotle
+kingler
+electabuzz
+tynamo
+frost rotom
+ampharos
+lanturn
+grovyle
+huntail
+cascoon
+heliolisk
+tapu fini gx
+nidoqueen
+shelgon
+dark pupitar
+bulbasaur
+hitmonlee
+metang
+ursaring
+double magma energy
+magcargo
+zapdos
+swanna
+diancie
+wartortle
+drednaw
+dodrio
+pokémon center
+galarian mr. mime
+charmeleon
+pikachu
+altaria
+pikachu δ
+stantler
+snorunt
+blitzle
+unown [i]
+minun
+barbaracle
+nidoking
+alolan golem
+weepinbell
+altaria
+golbat
+slugma
+dark muk
+zekrom
+shuppet
+plusle
+milotic
+wailord
+doduo
+bewear gx
+goldeen
+cherrim
+pokémon catcher
+sneasel
+ledian
+nidoran ♂
+drifloon
+machoke
+regirock ex
+quilava
+wobbuffet
+arbok
+helioptile
+blastoise gx
+unown [b]
+haunter
+magnemite
+zebstrika
+sableye
+dusclops
+galarian mr. rime
+nickit
+gorebyss
+altaria gx
+tapu fini gx
+cloyster
+elekid
+dark wartortle
+miltank
+ducklett
+tropical tidal wave
+nidorino
+kirlia δ
+xurkitree
+aron
+farfetch'd
+kangaskhan
+slowpoke
+skitty
+magneton
+arctozolt
+dragonair δ
+nuzleaf
+trevor
+caterpie
+aipom
+hariyama
+nidorina
+dark weezing
+raichu
+blitzle
+cryogonal
+swoobat
+emolga
+regirock
+emolga
+froslass
+erika's exeggcute
+zebstrika
+munna
+manaphy
+pelipper
+electrode g
+blitzle
+gorebyss
+thundurus
+exeggutor
+ursaring
+milotic
+ekans
+flareon
+probopass g
+eelektrik
+cramorant
+nuzleaf
+inkay
+cascoon
+primarina
+koga's kakuna
+houndour
+jumpluff
+lucky stadium
+igglybuff
+jolteon
+victini
+gengar
+golduck δ
+empoleon
+snorunt
+hydreigon
+arrokuda
+voltorb
+beldum
+squirtle
+fearow
+combusken
+minun
+relicanth
+koga's koffing
+mew ex
+lanturn
+heracross
+blastoise
+raikou ex
+zebstrika
+luvdisc
+sneasel
+unown [y]
+nidorino
+fearow
+keldeo
+duraludon v
+potion
+poliwag
+munna
+riolu
+slowpoke
+yanma
+dedenne
+granbull
+emolga
+magnezone
+sealeo
+drifloon
+magmar
+charmander
+emolga
+donphan
+wartortle
+electrode
+pidgeotto
+holon's castform
+dewgong
+kirlia
+ponyta
+geodude
+ekans
+jynx
+aron
+jirachi
+gyarados
+spheal
+machamp
+primarina gx
+golbat
+registeel
+gible
+bagon
+snover
+jigglypuff
+eelektross
+pikachu
+duskull
+electabuzz
+dark persian
+drifblim
+espeon gx
+magneton
+pokémon tower
+goldeen
+kyogre ex
+gastly
+heliolisk
+rotom
+ivysaur
+plusle
+qwilfish
+lickitung
+walrein
+jolteon
+magcargo gx
+erika's exeggutor
+finneon
+musharna
+inkay
+gengar gl
+magikarp
+metagross ex
+venipede
+beldum
+nidorino
+regirock ex
+noctowl
+nidorina δ
+magneton
+chansey
+swanna
+snorunt
+litwick
+haunter
+poliwag
+groudon ex
+diglett
+light dewgong
+arbok
+gloom
+grimer
+malamar
+panpour
+luxio
+dark primeape
+aipom
+electivire
+shedinja
+erika's gloom
+hariyama
+joltik
+electrode
+nidorino δ
+voltorb
+whiscash
+dodrio
+farfetch'd
+machamp
+onix
+kirlia
+skiploom
+plusle
+regice
+shelgon
+koga's pidgey
+abomasnow
+umbreon gx
+blastoise
+houndoom
+houndour
+sharpedo
+glaceon
+combee
+litwick
+stunfisk
+sableye g
+barraskewda
+corsola
+loudred
+spheal
+swablu
+grimer
+raichu
+magby
+team aqua's carvanha
+zebstrika
+dusclops
+uxie
+vikavolt gx
+weavile
+sandile
+whirlipede
+machamp
+m metagross ex
+gabite
+gyarados
+piloswine
+switch
+bellsprout
+froakie
+wartortle
+grovyle
+emolga
+electrike
+magmar
+cranidos
+quagsire
+kangaskhan
+magnezone
+illumise
+crabominable
+electrode
+lairon
+shelgon
+wormadam
+manectric
+miltank
+lumineon
+seaking
+togepi
+zekrom
+charizard g lv.x
+glalie
+kangaskhan
+rapidash
+gastly
+jynx
+drowzee
+kingdra
+swellow
+keldeo
+buizel
+noctowl
+houndoom
+meowth
+minun
+magmar
+kabuto
+electabuzz
+porygon2
+quilava
+kyogre
+frogadier
+decidueye gx
+togetic
+lickitung
+rayquaza ex
+fearow
+sandslash
+farfetch'd
+tierno
+panpour
+magnezone
+zorua
+quilava δ
+wishiwashi
+treecko
+lampent
+lampent
+salamence gx
+poliwhirl
+mesprit
+koga's weezing
+chinchou
+garchomp c lv.x
+beldum
+spheal
+butterfree
+riolu
+thundurus
+kadabra
+victini
+hippowdon e4
+muk
+lapras
+jolteon
+crobat g
+illumise
+erika's gloom
+lairon
+sealeo
+shelgon
+manectric
+scolipede
+snover
+emolga ex
+wingull
+torkoal
+galvantula
+haunter
+eevee
+bayleef
+pikachu v
+monferno
+doduo
+garchomp
+luvdisc
+altaria
+hypno
+parasect
+gengar
+eevee
+jynx
+light flareon
+mime jr.
+flaaffy
+electrike
+pikachu
+chinchou
+elekid
+team aqua's carvanha
+shelgon
+hariyama
+throh
+oricorio
+joltik
+keldeo ex
+lanturn
+aron
+stunky
+dark rapidash
+silcoon
+carnivine
+horsea
+doduo
+shinx
+electrode
+zekrom ex
+simipour
+mantine
+dustox
+slowbro
+azelf
+kabuto
+walrein
+togekiss
+joltik
+pikachu
+hatenna
+erika's oddish
+mothim
+stunky
+masquerain
+scyther
+lanturn
+solrock
+helioptile
+tentacruel
+shinx
+torchic
+team aqua's chinchou
+golduck
+entei
+jynx
+riolu
+wormadam plant cloak
+poliwrath
+lt. surge's eevee
+galarian darumaka
+marowak
+sigilyph
+huntail
+greninja
+kakuna
+electabuzz
+cherubi
+drifloon
+metang
+electivire
+feebas
+klink
+spheal
+light golduck
+rocket's meowth
+tapu koko gx
+dark vaporeon
+drowzee
+pelipper
+sawk
+druddigon
+ivysaur
+scyther
+seadra δ
+machoke
+rayquaza c lv.x
+simipour
+pikachu vmax
+vibrava
+chandelure
+dewpider
+farfetch'd
+joltik
+kakuna
+ekans
+eevee
+chandelure
+infernape e4
+unown [!]
+reshiram ex
+incineroar gx
+seaking
+bede
+voltorb
+abomasnow
+grovyle
+yamask
+grimer
+misdreavus
+kirlia
+vibrava
+starmie
+gengar
+eevee
+clamperl
+grotle
+houndour
+mew
+charizard
+lairon
+zapdos ex
+persian
+lapras v
+pidgeotto
+zekrom
+phanpy
+flaaffy
+chingling
+kabutops
+mr. mime
+espurr
+greninja break
+galvantula
+grotle
+shedinja
+lairon
+mismagius
+uxie
+starmie
+piloswine
+gastly
+pumpkaboo
+charizard
+unown
+kecleon
+quilava
+heliolisk
+feebas
+yamask
+shuckle
+dark wartortle
+electrode gx
+skorupi
+linoone
+basculin
+bulbasaur
+slowpoke
+lt. surge's electrode
+rotom
+milotic v
+jynx
+lapras vmax
+tentacool
+magneton
+krabby
+archen
+zekrom ex
+tropical wind
+lucario
+mudkip
+wormadam sandy cloak
+espeon
+electabuzz
+primarina gx
+lairon
+shelgon δ
+metagross
+togekiss
+snorlax
+unown
+pidgeotto
+skuntank
+kirlia
+rocket's wobbuffet
+haunter
+lickitung
+shedinja
+araquanid
+gastly
+cranidos
+kyurem ex
+voltorb
+persian δ
+tynamo
+light jolteon
+pachirisu
+eevee
+nidorina
+muk
+vibrava
+igglybuff
+haunter
+zapdos
+zekrom
+medicham
+hoopa
+pidove
+mewtwo gx
+flareon
+luxio
+sealeo
+joltik
+linoone
+arbok
+vanillite
+clamperl
+voltorb
+erika's weepinbell
+galarian darmanitan
+sigilyph
+vigoroth
+swablu
+ledian
+geodude
+full heal
+graveler
+chinchou
+team aqua's corphish
+spoink
+lileep
+pyukumuku
+archeops
+electrode
+joltik
+huntail
+kirlia
+wormadam trash cloak
+drifloon
+victreebel
+metagross
+chinchou
+metang
+poliwhirl
+bulbasaur
+manectric
+machoke
+gothita
+sandile
+meowstic
+parasect
+light machoke
+mewtwo
+spoink
+luxray
+kyurem
+tentacruel
+mankey
+cofagrigus
+machamp
+quagsire
+zekrom
+geodude
+eevee
+meowstic ex
+dialga
+croconaw
+heatran
+lt. surge's raticate
+hippopotas
+noibat
+qwilfish
+gothita
+jangmo o
+walrein
+eelektrik
+sableye
+goldeen
+omanyte
+smeargle δ
+shining mew
+electrode
+riolu
+gourgeist
+electabuzz
+growlithe
+hawlucha
+eevee
+tirtouga
+mew
+solrock
+tympole
+whiscash
+magneton
+audino
+horsea
+muk
+bill's analysis
+slowbro
+smeargle
+great ball
+machoke
+seadra
+magikarp
+pidgeotto δ
+kakuna
+tapu koko ◇
+kingdra
+prinplup
+erika's weepinbell
+leafeon
+vanillish
+aron
+zekrom ex
+houndoom g
+nidoran ♂
+loudred
+koffing
+unown
+dewgong
+haunter
+palpitoad
+white kyurem gx
+blaine's last stand
+ditto
+swellow
+lombre
+murkrow
+pachirisu
+articuno
+honedge
+porygon
+gligar
+bagon
+mantine
+metapod
+gligar
+grumpig
+jolteon
+wailmer
+mewtwo ex
+vanilluxe
+electivire
+bruxish
+vanillite
+magcargo
+houndour
+grimer
+mewtwo ex
+oranguru
+seviper
+clefable
+krokorok
+gorebyss
+arceus
+cofagrigus
+marshtomp
+nidoking
+latios
+galarian sirfetch'd v
+drifloon
+beldum
+zeraora
+skiploom
+gulpin
+magikarp
+registeel
+galvantula
+xatu
+gothorita
+magneton
+machamp gl
+raichu
+light ninetales
+vileplume
+carbink
+persian
+diglett
+slowpoke
+team aqua's corphish
+grumpig
+wigglytuff
+lt. surge's magnemite
+galvantula
+lileep
+bagon
+hop
+carbink
+kyogre
+cacnea
+kirlia
+trubbish
+nidorino
+victini
+primeape
+battle city
+quilava
+larvitar
+metang δ
+lanturn
+primeape δ
+bagon
+luxio
+spinda
+machop
+eelektross
+electabuzz
+magcargo
+carracosta
+komala
+ralts
+venipede
+nidoking
+ninetales
+trubbish
+bagon
+volcarona
+dugtrio
+team aqua's electrike
+togepi
+magnemite
+light slowbro
+ivysaur
+garbodor
+primeape
+snorlax
+carbink
+eternatus v
+hyper potion
+magcargo
+yanma
+tynamo
+baltoy
+electrike
+brock's grit
+litleo
+grimer
+wailord
+anorith
+klefki
+togedemaru
+kyogre ex
+growlithe
+beedrill g
+persian
+vigoroth
+rapidash e4
+cosmog
+larvitar
+larvitar
+lt. surge's raticate
+gothitelle
+zubat
+marshtomp
+vaporeon
+zygarde
+cloyster
+zapdos
+caterpie
+gengar & mimikyu gx
+metang
+shinx
+omastar
+froakie
+dodrio
+vanillish
+rotom
+shining jirachi
+nosepass
+magneton
+cresselia
+chimecho
+swellow δ
+psyduck
+charmander
+gliscor
+lombre
+slowbro
+munna
+paras
+quilava
+scyther
+raichu
+marshtomp
+misty's dewgong
+porygon
+cryogonal
+gothita
+miltank
+piplup
+machoke
+ralts
+gorebyss
+electivire
+metang
+seismitoad
+keldeo v
+natu
+type: null
+scraggy
+linoone
+shellder
+drifblim
+houndoom
+mightyena
+scizor e4
+staravia
+camerupt
+roggenrola
+leafeon gx
+octillery
+magmar
+kirlia
+slowking
+chikorita
+bronzor
+manectric
+lombre
+metagross
+weepinbell
+poliwhirl
+seel
+pupitar δ
+whirlipede
+prinplup
+dragonite
+keldeo gx
+weezing
+vanilluxe
+darkrai
+dunsparce
+musharna
+nidoran ♀
+metapod
+ampharos v
+nidoking break
+sobble
+lileep
+metapod
+celebi
+magmar
+brock's pewter city gym
+xatu
+light vaporeon
+tynamo
+charmander δ
+turtonator
+beldum
+miltank
+sabrina's haunter
+magneton
+togepi δ
+kyogre
+galarian darumaka
+chinchou
+garbodor
+muk
+seadra δ
+kirlia
+rapidash
+raticate
+hitmonchan
+gothorita
+drifloon
+chikorita
+luxio
+barboach
+frogadier
+dratini
+honedge
+luvdisc
+lucario
+magneton
+scrafty
+probopass
+chansey
+alolan meowth
+chinchou
+kabu
+eternatus vmax
+aron
+buneary
+galarian darmanitan
+groudon ex
+raikou
+marowak
+lanturn
+nidorina
+nidorino
+forretress
+venomoth
+quagsire
+hitmonlee
+bagon
+eldegoss
+cacnea
+luxray
+kyogre ex
+makuhita
+cubone
+pyroar
+mankey
+thundurus
+nuzleaf
+marnie
+slowpoke
+sharpedo δ
+gabite
+clefairy
+pikachu
+decidueye gx
+light venomoth
+vibrava δ
+diglett
+corphish
+togedemaru
+silcoon
+misdreavus
+empoleon
+gastly
+boldore
+zapdos
+kabuto
+chikorita
+machop
+pichu
+plusle
+dragonair
+dewpider
+nidoran ♂
+golett
+gardevoir
+drifblim
+gardevoir
+machop
+deoxys ex
+mantyke
+team aqua's electrike
+sabrina's hypno
+pupitar
+arceus lv.x
+castform
+chinchou
+wobbuffet
+dugtrio
+abra
+lombre
+carbink break
+rhydon
+scolipede
+golett
+drampa
+lt. surge's spearow
+doublade
+tentacool
+nidorina
+piloswine
+inteleon v
+zygarde
+beginning door
+gigalith
+diancie ex
+milo
+dragonite
+corphish
+scyther
+misty's poliwhirl
+clefairy
+phione
+team aqua's poochyena
+minun
+haunter
+tapu lele
+magby
+yamask
+castform rain form
+jangmo o
+phantump
+murkrow
+clefairy
+aegislash
+nidoqueen
+fearow
+lairon
+seviper
+durant
+houndour
+monferno
+parasect
+rapidash
+rapidash
+gothorita
+sharpedo
+zubat
+woobat
+sudowoodo
+mightyena
+eelektrik
+anorith
+blitzle
+pumpkaboo
+garbodor
+team aqua's poochyena
+gothita
+dewgong
+feraligatr
+araquanid
+machoke
+blacephalon gx
+pupitar
+cyndaquil
+skitty
+altaria c
+oricorio
+nidorino
+nuzleaf
+electrike
+sigilyph
+dratini
+nuzleaf
+porygon2
+duskull
+golurk
+zubat
+starmie
+yamask
+nidoran ♂
+mismagius
+rhydon
+bagon δ
+flabébé
+cottonee
+charjabug
+drowzee
+magneton
+seaking
+spiritomb
+burmy plant cloak
+unown [q]
+baltoy
+solosis
+m diancie ex
+tornadus
+munna
+light wigglytuff
+swoobat
+primal kyogre ex
+gourgeist
+armaldo
+wartortle
+charmander
+golurk
+castform snow cloud form
+raichu
+sabrina's jynx
+gothitelle
+ho oh
+piers
+seadra
+cubchoo
+cyndaquil
+magnemite
+corphish
+seviper
+golisopod gx
+trevenant
+vibrava δ
+misdreavus
+misty's psyduck
+ultimate zone
+qwilfish
+shelgon δ
+pidgeotto
+eelektross
+meditite
+luxray break
+onix
+mr. mime gx
+geodude
+flabébé
+raichu break
+zygarde
+sealeo
+landorus
+salandit
+pelipper
+shelgon δ
+zebstrika
+cyndaquil
+golbat
+nidorino
+drednaw
+mr. fuji
+brock's training
+trubbish
+musharna
+koffing
+houndour
+marshadow
+burmy sandy cloak
+eevee
+castform sunny form
+manaphy
+scyther
+kadabra
+tauros
+gallade ex
+aipom
+crabominable
+yanmega
+feraligatr
+hakamo o
+duskull
+espeon
+dragonite
+girafarig
+unown [d]
+misty's seaking
+aggron
+prinplup
+tympole
+chikorita δ
+mismagius
+electrike
+team aqua's spheal
+weepinbell
+natu
+murkrow
+dratini
+skorupi
+gothitelle
+sobble
+nuzleaf
+venipede
+wimpod
+inteleon vmax
+inkay
+carvanha
+omanyte
+whimsicott
+skiploom
+croagunk
+remoraid
+alolan vulpix
+vikavolt
+parasect
+whiscash
+arcanine
+primeape
+cofagrigus
+dark raticate
+beartic
+machop
+barboach
+monferno
+eevee
+pumpkaboo
+suicune
+golisopod
+spinda
+nidoking
+unown [f]
+makuhita
+manectric
+togepi
+sunflora
+poké ball
+charizard gx
+zygarde ex
+charmander
+pinsir
+blitzle
+rapidash
+drowzee
+pidgey
+aipom
+sabrina's kadabra
+aipom
+crobat
+drapion
+skarmory
+gulpin
+team aqua's spheal
+whirlipede
+darmanitan
+porygon2
+roggenrola
+krabby
+steelix gl
+stunfisk
+kakuna
+toxicroak
+kommo o
+burmy trash cloak
+jigglypuff
+slakoth
+quagsire
+geodude
+misty's starmie
+centiskorch
+moltres
+kyurem
+floette
+golbat
+flaaffy
+machamp
+shuckle
+garbodor
+hitmonchan
+onix
+gothorita
+ralts
+bibarel
+duosion
+cyndaquil δ
+wobbuffet
+wigglytuff
+togedemaru
+giratina ex
+slowking
+mewtwo
+sableye
+malamar
+ducklett
+jirachi ex
+beldum
+erika's hospitality
+cramorant
+drizzile
+magnemite
+diglett
+altaria
+salazzle
+pelipper
+drowzee
+chinchou
+gengar
+wishiwashi
+machoke
+dusclops
+altaria
+weepinbell
+dragonair
+wobbuffet
+skiploom
+sabrina's mr. mime
+carvanha
+mawile
+unown [m]
+honchkrow
+magnemite
+persian
+nidoqueen
+drizzile
+purugly
+elgyem
+quilava
+dubwool v
+zubat
+koffing
+cofagrigus
+golem
+gourgeist
+graveler
+muk
+bellsprout
+starmie
+reuniclus
+arceus lv.x
+scyther
+lanturn
+team magma's aron
+rapidash
+chinchou
+anorith δ
+gothita
+zygarde
+gligar
+bagon
+machoke
+exeggcute
+kirlia
+heliolisk
+kingler
+seedot
+breloom
+grimer
+misty's tentacool
+woobat
+unown [c]
+arrokuda
+pikachu
+sneasel
+escavalier
+spiritomb
+giovanni's exile
+scolipede
+mareanie
+croagunk
+mudkip
+skrelp
+drifblim
+mewtwo ex
+tropius
+volbeat
+zygarde ex
+dratini δ
+oranguru
+bellsprout
+floette
+machamp
+dusknoir
+ho oh gx
+swellow
+ekans
+bronzor
+blitzle
+energy search
+pokémon center lady
+spoink
+geodude
+krabby
+goomy
+pyukumuku
+kangaskhan
+zebstrika
+mewtwo ex
+quagsire
+magikarp
+croagunk
+duskull
+grimer
+octillery
+poliwag
+toxapex
+weavile
+shelgon
+bagon δ
+charmander
+hitmonlee
+aron
+roggenrola
+togepi
+gothitelle
+slowpoke
+swanna
+numel
+tentacool
+dratini
+drowzee
+onix
+electrike
+rhydon
+exeggutor
+sliggoo
+purrloin
+meowstic
+jessie & james
+swalot
+swablu
+girafarig
+zebstrika
+nidoking
+carnivine
+horsea
+graveler
+team magma's aron
+bagon
+bulbasaur
+lotad
+bagon
+happiny
+kingler
+poochyena
+vigoroth
+charizard v
+relicanth
+diglett
+umbreon ex
+goldeen
+gloom
+swalot
+reuniclus
+gambler
+blaine's charmander
+potion
+yamask
+solosis
+golbat
+barraskewda
+buneary
+sentret
+dragalge
+nihilego gx
+hitmonlee
+mew
+beheeyem
+omastar
+scizor
+inteleon
+reshiram gx
+toxicroak
+vigoroth
+sableye
+vibrava
+bewear
+sabrina's haunter
+koffing
+gothorita
+florges
+unown [p]
+corphish
+unown [n]
+poliwhirl
+raticate
+ekans δ
+aron
+magneton
+seaking
+shelgon
+unown [q]
+ponyta
+whiscash e4
+regirock
+oricorio
+raticate
+koga's trap
+duskull
+machamp
+riolu
+mankey
+kabuto
+spiritomb
+black kyurem
+drowzee
+team magma's baltoy
+inteleon
+prinplup
+goodra
+professor's research (professor magnolia)
+boldore
+meowth
+shuppet
+unown [u]
+poliwag
+weezing
+lapras
+numel
+sabrina's jynx
+meditite
+skarmory
+magnezone
+dugtrio
+slugma
+bulbasaur
+recycle
+growlithe
+wailmer
+volbeat
+crobat
+houndour
+gothitelle
+elekid δ
+tapu fini
+baltoy
+piloswine
+slowbro
+croagunk
+seviper
+cherubi
+cubone
+joltik
+xatu
+mankey
+spritzee
+hitmonchan
+mightyena
+riolu
+duosion
+shelgon
+elgyem
+hypno
+golem
+eiscue
+chatot g
+swablu
+gliscor
+grumpig
+cofagrigus
+hoothoot
+roselia
+tentacruel
+blaine's doduo
+houndour
+burmy sandy cloak
+tapu koko gx
+giratina ◇
+dracovish
+turtonator gx
+bagon δ
+sandshrew
+darkrai ex
+slowking
+bellsprout
+electrike
+spoink
+lairon
+tentacruel
+hoppip
+hoopa
+toxicroak
+tyranitar
+liepard
+misdreavus
+rhydon
+mysterious fossil
+pawniard
+lapras
+scraggy
+carbink
+diglett
+seaking
+poipole
+wishiwashi
+spiritomb
+grimer
+eiscue v
+smoochum
+chatot
+alolan meowth
+oricorio
+horsea
+boldore
+manectric
+probopass
+wynaut
+eevee
+rayquaza ex
+grumpig
+seaking
+ralts
+feebas δ
+croagunk
+pangoro
+hitmontop
+blaine's last stand
+staravia
+lucario
+elgyem
+rhyhorn
+raikou
+magikarp
+caterpie
+eevee
+houndour
+golem ex
+rotom bike
+sabrina's slowbro
+chikorita
+cherrim
+barboach
+rattata
+mudkip
+lileep
+kyurem
+remoraid
+grumpig
+electrike
+aerodactyl
+golett
+magmar
+bronzor
+koffing
+sableye
+pichu
+skitty
+reuniclus
+unown [z]
+cresselia
+hoothoot
+raichu & alolan raichu gx
+murkrow
+venipede
+salamence
+salamence
+aron
+slowking
+alolan ninetales gx
+beldum δ
+skarmory
+metapod
+baltoy
+duskull
+meowth
+xatu
+espeon ex
+primeape
+magby
+primeape
+arctovish
+gengar
+blaine's growlithe
+aerodactyl gl
+galvantula
+alolan grimer
+politoed
+chewtle
+vullaby
+team magma's baltoy
+toxicroak
+lt. surge's strategy
+chimchar
+hitmonlee
+tynamo
+snubbull
+meganium
+houndoom
+pikachu
+cubone
+persian
+aron
+whirlipede
+spheal
+timburr
+blaine's mankey
+articuno gx
+magikarp
+delibird
+murkrow
+kyogre
+seel
+magnemite
+cubone
+seviper
+horsea δ
+shelgon
+houndour
+larvitar
+voltorb
+froakie
+wishiwashi gx
+drednaw
+riolu
+blaine's charmander
+mudkip
+dragonite fb
+chimchar
+bisharp
+golurk
+latios ex
+electrike
+poliwrath
+carvanha
+gigalith
+m charizard ex
+baltoy
+beheeyem
+charmander
+cyndaquil
+hippopotas
+masquerain
+dusclops
+tynamo
+ekans
+slowbro
+nidorina
+hoppip
+onix
+staryu
+carvanha δ
+exeggcute
+lunatone
+woobat
+breloom
+hitmonchan
+dragon talon
+naganadel gx
+caterpie
+muk
+ambipom g
+sandshrew
+rotom phone
+meganium
+eelektrik
+groudon ex
+misty's cerulean city gym
+xatu
+cosmog
+golisopod
+kirlia
+mandibuzz
+machop
+chikorita
+mareep
+machamp
+team magma's houndour
+dugtrio
+silcoon
+stunfisk
+electrike
+toxapex gx
+skorupi
+dialga ex
+steelix
+rhydon
+purrloin
+alolan muk
+bagon
+scrafty
+altaria
+pikachu
+blaine's growlithe
+lanturn
+chingling
+dhelmise
+mimikyu
+yveltal
+magmar
+roselia
+coalossal
+skiploom
+flaaffy
+palkia ex
+mareep
+sonia
+squirtle
+blaine's ponyta
+goldeen
+goldeen
+ditto
+eelektrik
+carvanha
+liepard
+lanturn
+drilbur
+beldum
+jigglypuff
+gallade
+nidorina
+togetic
+tauros
+blaine's ponyta
+mew
+machop
+raichu
+lilligant
+electrode
+rhyhorn
+zorua
+drowzee
+corphish
+litwick
+eelektrik
+magnemite
+pikachu
+groudon
+dhelmise
+dedenne
+dewpider
+fiery flint
+aron
+cosmoem
+scolipede
+magnemite
+aron
+dark octillery
+swoobat
+makuhita
+cubone
+houndour
+ralts
+mantine
+electrike
+cubone
+cramorant
+team magma's houndour
+lucario
+drilbur
+hippowdon
+oddish
+charmander
+frogadier
+drapion
+druddigon
+drifblim
+rhyperior
+solrock
+makuhita
+nidorino
+swinub
+eevee
+chinchou
+wormadam
+dunsparce
+combee
+shieldon
+glaceon gx
+grimer
+m latios ex
+larvitar
+cubone
+bidoof
+alolan marowak
+sudowoodo
+regirock
+dusknoir
+numel
+timburr
+misty's determination
+staravia
+tentacool
+smeargle
+raikou
+tropical beach
+jynx
+spearow
+yveltal break
+hypno
+crobat
+pikachu
+jigglypuff
+starmie
+suicune
+machoke
+fiery flint
+trapinch
+koffing
+koffing
+gurdurr
+chikorita
+litwick
+clefairy
+omanyte
+blaine's rhyhorn
+decidueye
+hatterene v
+marowak
+mareep
+electrike
+pyukumuku
+unown [a]
+eelektross
+hoppip
+excadrill
+porygon
+dragalge
+gastrodon
+ampharos
+croagunk
+meditite
+malamar ex
+suicune
+ditto
+rayquaza ex
+bronzor
+giratina
+alolan raichu
+shuppet
+starmie
+sigilyph
+team magma's numel
+clefairy
+corphish
+axew
+gastly
+larvitar δ
+suspicious food tin
+wartortle
+mienfoo
+greninja gx
+electabuzz
+magnemite
+smoochum
+gastly
+koffing
+torterra
+bronzor
+silcoon
+diglett
+koffing
+araquanid
+espurr
+floatzel
+lunala ◇
+sceptile ex
+eelektross
+cyndaquil
+dratini
+snom
+zoroark gx
+sigilyph
+cacnea
+tapu lele gx
+ledian
+blaine's tauros
+lunatone
+rhyhorn
+seedot
+drilbur
+unown [f]
+squirtle
+unown [k]
+hariyama
+natu
+octillery
+croagunk
+rhydon
+mewtwo
+hariyama
+carvanha
+misty's water command
+parasect
+electrike
+infernape
+pokémon center lady
+zubat
+lillipup
+skarmory
+larvitar
+frosmoth
+dratini
+solrock
+team magma's poochyena
+magnemite
+team yell grunt
+dawn wings necrozma gx
+m rayquaza ex
+tentacruel
+kabuto
+lucario
+stantler
+spearow
+tapu lele gx
+exeggcute
+staryu
+umbreon
+trubbish
+clefable
+throh
+cherubi
+bronzong
+starmie
+weepinbell
+lampent
+ninetales
+stufful
+geodude
+pineco
+mawile
+mr. mime
+cacnea
+goomy
+blaine's vulpix
+gabite
+yveltal
+blaziken ex
+lance ◇
+electrode gx
+croagunk
+unown [b]
+fraxure
+electrike
+excadrill
+nidoran ♀
+omanyte
+electivire
+ledyba δ
+blaine's vulpix
+trubbish
+cubone
+machop
+pikachu
+lotad
+ledyba
+tsareena gx
+morpeko v
+oddish
+trapinch
+electrike
+drifloon
+meowstic
+nosepass
+haunter
+shroomish
+espeon gx
+unown [k]
+eevee
+zekrom
+chinchou
+porygon2
+trubbish
+machamp
+suicune gx
+ditto
+mienshao
+mareep
+unown [g]
+steelix ex
+omastar
+shuppet
+mankey
+vigoroth
+cyndaquil
+voltorb
+pikachu
+excadrill
+pikachu
+raichu
+bronzor
+hoopa
+swampert ex
+unown [c]
+banette
+sabrina's suggestion
+misdreavus
+cyndaquil
+primeape
+chinchou
+team magma's poochyena
+abra
+turffield stadium
+switch raft
+luxio
+tangela
+sneasel
+larvitar
+togetic
+gengar
+onix
+bronzong break
+flygon
+wailmer
+gible
+pichu
+m steelix ex
+garchomp c
+manectric
+brock's diglett
+exeggcute δ
+sneasel
+magnemite
+timburr
+timburr
+balloon berry
+wailmer
+diglett
+combee
+spoink
+wartortle
+bewear
+garbodor
+toxicroak
+eevee
+mr. mime
+porygon z
+nidorina
+haxorus
+sliggoo
+pupitar
+baltoy
+magikarp
+sawk
+gastly
+mudkip
+ho oh gx
+gulpin
+magneton
+lunala
+hydreigon ex
+brock's geodude
+cubchoo
+xurkitree gx
+cranidos
+chandelure
+unown [n]
+excadrill
+zeraora
+flareon e4
+larvitar
+machamp break
+meowth
+mareep δ
+girafarig
+pineco
+grimmsnarl v
+steelix
+lucario ex
+mr. mime gx
+gastly
+teddiursa
+raichu
+trubbish
+pikachu
+sandygast
+garbodor
+koffing
+snorunt
+magikarp
+mareanie
+ditto
+shinx
+zangoose
+forretress g
+goodra
+quilava
+zangoose
+mankey
+gurdurr
+squirtle
+phanpy
+gabite
+rampardos
+drednaw v
+palossand
+lucario
+rapidash
+weavile
+rattata
+beartic
+horsea δ
+alcremie
+pineco
+clamperl
+magnemite
+weavile
+onix
+hippopotas
+meowth
+illumise
+trubbish
+dratini δ
+buzzwole gx
+porygon z
+claydol
+vikavolt v
+natu δ
+team magma's rhyhorn
+kabuto
+pincurchin
+wurmple
+unown [o]
+eevee
+reshiram
+brock's mankey
+moltres & zapdos & articuno gx
+pikachu
+makuhita
+espurr
+pidgeot
+blissey
+voltorb
+drifloon
+tyranitar
+poochyena
+mareep
+nidoqueen
+gothita
+umbreon
+ledyba
+bellsprout
+unown [d]
+doduo
+tropius
+healing field
+necrozma gx
+nincada
+shining rayquaza
+dunsparce
+spoink
+banette gx
+raichu
+m lucario ex
+mewtwo gx
+machop
+shieldon
+goldeen
+bronzong
+sandile
+brock's geodude
+mewtwo ex
+magnezone
+luxio
+cresselia ex
+gigalith
+nidoran ♀
+stunfisk
+marowak
+wela volcano park
+gurdurr
+druddigon
+jynx
+gligar
+mareep
+throh
+girafarig
+toxapex
+gligar
+electrike
+makuhita
+shining arceus
+dialga ex
+elgyem
+gliscor e4
+hoothoot
+krokorok
+natu
+erika's jigglypuff
+cacnea
+umbreon
+vaporeon
+azurill
+garbodor
+raticate
+sandslash
+joltik
+dedenne gx
+kricketot
+genesect ex
+baltoy
+absol
+ivysaur
+m lucario ex
+cyndaquil
+nidoran ♀ δ
+scyther
+giovanni's exile
+unown [x]
+meowth
+espeon gx
+vulpix
+metang
+kangaskhan
+magikarp
+bastiodon
+pidgey
+houndour
+fearow
+clefairy
+duskull
+gothita
+wynaut
+pidgey
+persian
+poliwrath
+nidoqueen
+conkeldurr
+galarian obstagoon
+cosmog
+mewtwo ex
+munna
+zinnia
+ralts
+hitmonchan
+white kyurem
+gastly
+team magma's rhyhorn
+roggenrola
+makuhita
+timburr
+poliwag
+spoink
+marill
+gardevoir v
+meowstic
+deoxys
+umbreon
+necrozma gx
+riolu
+turtwig
+nuzleaf
+luxray
+natu
+nincada
+lugia ex
+chinchou
+team aqua schemer
+cosmoem
+hoppip
+honedge
+garbodor
+carnivine
+gurdurr
+malamar
+clefairy
+omanyte
+duskull
+popplio
+galarian cursola v
+heatran
+empoleon
+sandile
+krookodile
+weedle
+tapu koko
+buizel
+sandslash
+slowpoke
+pokémon breeder fields
+duskull
+oddish
+lickitung
+houndoom
+jessie & james
+musharna
+vulpix
+doduo
+squirtle
+duraludon
+nincada
+oddish
+erika's oddish
+makuhita
+sealeo
+wigglytuff
+machamp gx
+marshadow gx
+growlithe
+pineco
+nosepass
+lucario
+boldore
+cursed stone
+damage mover
+unown [z]
+victreebel
+swablu
+sableye
+growlithe
+ace trainer
+galvantula
+metang
+porygon
+kabuto δ
+chinchou
+banette gx
+lopunny
+umbreon
+m mewtwo ex
+bidoof
+charjabug
+cosmog
+helioptile
+garchomp
+brock's mankey
+magnemite
+growlithe
+tentacool
+seedot
+sawk
+doduo
+machop
+clefable
+shiftry
+pidgeotto
+glameow
+dratini δ
+zekrom
+energy retrieval
+raichu
+pidgeot
+hippopotas
+vikavolt
+nidoran ♂ δ
+rhyhorn
+klink
+makuhita
+xatu
+clefairy doll
+pineco
+erika's paras
+purrloin
+girafarig
+haxorus
+venomoth
+krokorok
+chansey
+dodrio
+salamence
+reshiram gx
+cosmoem
+rocket's hideout
+brock's onix
+machop
+shuppet
+mightyena
+scraggy
+vileplume
+bulbasaur
+horsea
+tynamo
+loudred
+popplio
+pikachu v
+drowzee
+moltres & zapdos & articuno gx
+finneon
+lileep δ
+deino
+jigglypuff
+gothorita
+sableye
+slugma
+sandile
+cacnea
+ampharos spirit link
+porygon2
+bonsly
+poliwhirl
+jigglypuff
+doublade
+deoxys
+hippopotas
+nincada
+spearow
+numel
+mienfoo
+nihilego gx
+paras
+team magma schemer
+seadra
+mankey
+weedle
+heliolisk
+charizard gx
+lanturn
+tentacool
+sandile
+magneton
+mareep
+hippopotas
+grapploct v
+meowth
+woobat
+croagunk
+duskull
+omanyte
+relicanth
+taillow
+pidgeot ex
+feebas
+hitmonchan
+black kyurem
+pikachu
+primeape
+fearow
+eco arm
+swoobat
+brionne
+ledyba
+tentacruel
+shedinja
+slowpoke
+torchic
+krokorok
+jolteon
+hop
+m mewtwo ex
+porygon z
+torchic
+krookodile
+vibrava
+gothitelle
+archie
+rapidash
+gigalith
+pupitar
+elgyem
+m pidgeot ex
+zweilous
+fieldworker
+gastly
+shieldon
+ninjask
+brock's rhyhorn
+snorlax
+sneasel
+kangaskhan ex
+wigglytuff
+skitty
+caterpie
+pikachu
+scrafty
+joltik
+tauros
+caterpie
+computer search
+charjabug
+rhydon
+numel
+krabby
+marill
+poliwag
+darkrai ex
+mienshao
+machoke
+mudkip
+liepard
+kingdra gx
+naganadel gx
+great ball
+toxicroak
+deoxys
+escavalier
+toxel
+magikarp δ
+zubat
+ponyta
+conkeldurr
+chimchar
+giovanni's machop
+zeraora
+klang
+gyarados
+hippowdon
+porygon
+houndoom e4
+eternatus v
+old rod
+electrode
+numel
+larvitar
+magmar
+tynamo
+gulpin
+lunala gx
+tapu bulu
+krokorok
+venipede
+rhyperior
+charmander
+pupitar
+onix
+snubbull
+pineco
+pancham
+flygon ex
+pupitar δ
+pawniard
+manectric g
+stunky
+passimian
+skarmory
+solosis
+treecko
+shuppet
+shining gyarados
+muk & alolan muk gx
+lucario gx
+ledyba
+bronzor
+psyduck
+krookodile
+krookodile
+conkeldurr
+white kyurem
+dragonite gx
+snorlax
+machamp
+meowth
+tauros
+phanpy
+vikavolt
+torchic
+mr. mime
+makuhita
+rhyhorn
+cheerleader's cheer
+charizard vmax
+eevee δ
+throh
+kabuto
+primarina
+hitmonlee
+devolution spray
+hydreigon
+toxtricity
+hau
+tropius
+lunala
+sandile
+slakoth
+golisopod gx
+larvitar
+elgyem
+giovanni's magikarp
+rattata
+clamperl
+mudkip
+scraggy
+buizel
+mankey δ
+aegislash
+jigglypuff
+teddiursa
+klinklang
+eelektrik
+mantine
+zapdos
+magnemite
+energy recycler
+dual ball
+brock's sandshrew
+landorus
+combee
+m kangaskhan ex
+starmie
+magikarp
+eevee v
+misdreavus
+persian
+chinchou
+sentret
+kabuto
+ponyta
+paras
+galvantula
+eevee
+full flame
+aegislash ex
+wartortle
+kakuna
+ekans
+altaria gx
+scrafty
+spinarak
+snorlax
+phanpy
+hitmonchan
+piloswine
+machop
+pincurchin
+dual ball
+bagon
+meowth δ
+machop
+solosis
+ekans
+slugma
+buneary
+giant stump
+lanturn
+kecleon
+rattata
+onix
+mareanie
+giovanni's meowth
+tangela
+skrelp
+keldeo
+magnemite
+charizard
+terrakion
+numel
+treecko
+mareep
+hariyama
+eevee
+zorua
+ursaring
+cubone
+binacle
+remoraid
+shining magikarp
+murkrow
+pancham
+raticate
+typhlosion
+brock's sandshrew
+dunsparce
+rhyhorn
+salazzle gx
+light sunflora
+spearow
+archen
+togepi
+whirlipede
+unown [e]
+banette
+diglett
+poochyena
+bellsprout
+rattata
+absol ex
+mismagius
+bronzong
+lunatone
+clemont
+guzzlord gx
+impostor professor oak
+snorunt
+pawniard
+sawk
+lillie
+faded town
+tentacruel
+machoke
+eelektross
+snubbull
+boltund v
+munchlax
+nidoran ♀
+ralts
+maxie
+drednaw vmax
+beheeyem
+aegislash ex
+drowzee
+krokorok
+sudowoodo
+psyduck
+zygarde gx
+marshtomp
+cobalion
+voltorb
+tapu koko v
+koffing
+stunfisk
+duosion
+purrloin
+emcee's chatter
+strength charm
+stunfisk
+growlithe
+rattata
+keldeo ex
+nidoran ♂
+wobbuffet
+vulpix
+marill
+duskull
+spoink
+phanpy
+ferroseed
+gligar
+rhydon
+blaine's last stand
+numel
+dodrio
+guzzlord gx
+pikachu
+meowth
+teddiursa
+honchkrow
+omanyte
+slowpoke
+forest of giant plants
+pokémon breeder
+dunsparce
+magearna ex
+sentret
+scolipede
+solrock
+teddiursa
+chatot
+krookodile
+magikarp
+slowpoke
+masquerain
+roggenrola
+brock's vulpix
+chatot
+seadra
+omanyte
+giovanni's nidoran ♀
+m absol ex
+dracozolt
+treecko δ
+silvally
+machop
+holon's magnemite
+klefki
+abra
+togedemaru
+farfetch'd
+skarmory
+venonat
+m altaria ex
+toxapex
+phantump
+munchlax
+bisharp
+ralts δ
+donphan
+bulbasaur
+archeops
+zoroark
+barbaracle
+terrakion ex
+arbok
+crushing hammer
+yamper
+lycanroc gx
+phanpy
+gardevoir vmax
+zorua
+ekans
+seedot
+typhlosion
+phanpy
+misdreavus
+spheal
+shinx
+meditite
+diglett
+item finder
+unown [m]
+burned tower
+toxel
+power tree
+pancham
+squirtle
+arctozolt
+rayquaza
+brock's zubat
+sandshrew
+thundurus
+flaaffy
+dusclops
+furret
+voltorb
+shroomish
+caitlin
+cottonee
+liepard
+whismur
+bulbasaur
+rhyperior
+scraggy
+boldore
+spoink
+jigglypuff
+metang
+team aqua ball
+totodile
+oddish δ
+seel δ
+starmie
+giovanni's nidoran ♂
+trevenant
+toxtricity
+inkay
+lotad
+sentret
+zinnia
+doduo
+energy returner
+yamper
+ralts
+meditite
+defender
+alolan raichu
+erika's bellsprout
+furret
+cherubi
+doduo
+togedemaru
+holon's voltorb
+hex maniac
+marill
+tyrunt
+feebas
+lass
+zubat
+black kyurem ex
+gliscor
+poké ball
+natu
+gothita
+poochyena
+sneasel
+energy switch
+zoroark
+tyrunt
+unown [t]
+florges ex
+snorlax
+magnemite
+latios
+jigglypuff
+reuniclus
+whismur
+swablu
+rattata
+electrike
+snorunt
+noctowl
+tyrogue
+donphan
+kabu
+mawile
+murkrow
+munchlax
+donphan
+pidgey
+stunfisk
+bruxish
+riolu
+pokémon catcher
+lycanroc gx
+strange cave
+bisharp
+taillow
+tyranitar
+nidoran ♀
+mantine
+pikachu
+omastar
+slugma
+burmy plant cloak
+tapu koko
+miltank
+zubat
+cover fossil
+swalot
+wigglytuff
+zorua
+omanyte δ
+drowzee
+vigoroth
+mienfoo
+mareep
+chimchar
+caterpie
+weavile
+honchkrow
+kabuto
+chansey
+lugia
+minun
+omanyte
+rayquaza ex
+chandelure ex
+magnemite
+buzzwole gx
+azumarill
+shellder δ
+here comes team rocket!
+toxtricity v
+swablu
+pokémon breeder
+erika's bellsprout
+xurkitree
+claw fossil
+team aqua belt
+nidoran ♂
+gigalith
+vullaby
+energy exchanger
+nidoran ♀
+snubbull
+koga's ekans
+piers
+electabuzz
+venusaur
+swellow
+tyrantrum
+larvitar
+oddish
+rhyperior
+lunatone
+evosoda
+koffing
+lotad
+buneary
+engineer's adjustments
+piplup
+deino
+reshiram gx
+energy retrieval
+boltund
+phanpy
+swellow
+inkay
+grimer
+whimsicott
+swirlix
+solgaleo & lunala gx
+white kyurem ex
+wingull
+ponyta
+torchic
+dusknoir
+golbat
+nosepass
+unown [e]
+burmy sandy cloak
+mew v
+kirlia
+glameow
+trevenant break
+scrafty
+gothorita
+sophocles
+slakoth
+zigzagoon
+poochyena
+tangela
+vulpix
+pheromosa gx
+zoroark
+lucario
+milotic
+wigglytuff
+tyrantrum
+remoraid
+slowpoke
+aron
+gloom
+jirachi
+celesteela gx
+iris
+barboach
+bill's maintenance
+kabutops
+castaway
+crobat
+paras
+piplup
+meloetta
+trapinch
+venusaur
+whiscash
+marill
+mewtwo & mew gx
+imakuni?
+drifblim
+larvitar δ
+onix
+koga's grimer
+solrock
+jirachi
+happiny
+chimecho
+tauros
+poochyena
+swellow
+grookey
+nidoran ♂
+crabrawler
+cresselia
+mandibuzz
+battle frontier
+good rod
+mysterious fossil
+unown [i]
+altaria gx
+plume fossil
+pupitar
+pichu δ
+xurkitree gx
+toxtricity vmax
+malamar
+hawlucha
+persian
+stunky
+snubbull
+charizard v
+spinarak
+phanpy
+larvitar
+exeggcute
+lairon
+abra
+misdreavus
+deino
+super scoop up
+hawlucha
+sudowoodo
+oddish
+pokémon trader
+slurpuff
+minun
+golduck
+electivire
+tangela
+smoochum δ
+sawk
+snubbull
+lopunny
+cheerleader's cheer
+vullaby
+level ball
+gardevoir ex
+houndour
+flower shop lady
+koffing
+umbreon gx
+team aqua conspirator
+erika's exeggcute
+mienshao
+slugma
+meloetta
+diancie ex
+houndour
+porygon
+burmy trash cloak
+charmander
+sandshrew
+zorua
+clefairy
+taillow
+porygon
+boltund
+meowth
+rocket's sneak attack
+nosepass
+erika's oddish
+koga's koffing
+pancham
+shellos east sea
+riolu
+jigglypuff
+chesnaught
+magnemite
+gastly
+meditite
+unown [o]
+carvanha
+persian
+slugma
+pincurchin v
+weezing
+malamar
+legend box
+double full heal
+m gardevoir ex
+interviewer's questions
+swablu
+granbull
+zweilous
+fletchling
+koga's pidgey
+woobat
+mandibuzz
+torchic
+crabrawler
+spinarak
+scorbunny
+plusle
+tentacruel
+pikachu
+ninetales
+treecko
+rayquaza ex
+doduo
+celio's network
+dedenne
+golett
+root fossil
+pineco
+dragonite ex
+onix
+makuhita
+chinchou
+darkrai gx
+skuntank
+nidorina
+kingdra ex
+sandshrew
+zygarde
+spearow
+lucky helmet
+lucario
+swablu δ
+copycat
+erika's tangela
+pokémon catcher
+the boss's way
+switch
+suspicious food tin
+rockruff
+aggron
+espeon & deoxys gx
+klink
+honchkrow g
+pidgey δ
+maintenance
+riolu
+zorua
+vulpix
+gible
+vileplume
+ralts
+pidgey
+woobat
+sentret
+piloswine
+gastly
+cleffa
+pincurchin
+igglybuff
+scoop up
+meditite
+sunkern
+psyduck
+growlithe
+aipom
+team aqua hideout
+salamence gx
+pupitar
+passimian
+hawlucha ex
+houndoom
+murkrow
+natu
+buzzwole gx
+furfrou
+koga's tangela
+altaria
+yveltal
+charmander
+swoobat
+medicham
+goldeen
+klefki
+challenge!
+meowth
+registeel
+regigigas ex
+cessation crystal
+tyrantrum ex
+weezing
+clefairy
+starly
+ampharos
+lunatone
+lt. surge's magnemite
+darkrai ◇
+blacksmith
+vaporeon
+treecko
+rhyhorn
+jigglypuff
+dual ball
+stunky
+pikachu
+lanette's net search
+nidorino
+ralts
+baltoy
+rainbow energy
+pikachu
+weedle
+judge
+super energy removal
+gabite
+trapinch
+illumise
+professor juniper
+diancie
+yveltal ex
+ultra ball
+riolu
+aron
+teddiursa
+slowpoke
+magnemite
+lysandre
+kricketot
+golurk
+exeggcute
+team aqua technical machine 01
+rayquaza ex
+sandslash
+sandygast
+ninjask
+shining ho oh
+gastly
+dratini
+white kyurem gx
+gallade
+drapion
+natu
+hydreigon
+ruins of alph
+crabominable
+pancham
+klang
+starmie
+morpeko
+ferroseed
+combee
+omanyte
+spoink
+zygarde
+lycanroc gx
+max revive
+taillow δ
+pikachu
+blastoise spirit link
+zoroark
+morpeko
+koga's weedle
+porygon
+shuppet
+guzzlord gx
+unown [j]
+staryu
+lanturn
+medicham
+marill
+wynaut
+elgyem
+sentret
+swoobat
+stunky
+nuzleaf
+lt. surge's pikachu
+escavalier
+blacksmith
+sobble
+claydol
+drowzee
+brock's grit
+xerneas
+defender
+mareep
+dragon talon
+exeggutor
+kangaskhan
+wobbuffet
+interviewer's questions
+wingull
+poliwag
+digger
+clefairy
+special delivery pikachu
+pikachu δ
+zygarde gx
+shuckle
+bayleef
+marill
+slugma
+sunkern
+jigglypuff
+medicham
+haunter
+scizor gx
+ultra ball
+beheeyem
+crystal beach
+duskull
+cottonee
+kartana gx
+staryu
+steelix
+sage's training
+fiery torch
+life herb
+xatu
+totodile
+skuntank
+ponyta
+kommo o gx
+rare candy
+trapinch
+pidove
+bisharp
+lycanroc
+totodile δ
+gligar
+hoopa ex
+olympia
+palossand
+ferroseed
+turtwig
+quagsire gl
+lucario
+lum berry
+seedot
+paint roller
+mudbray
+klinklang
+skorupi
+numel
+barboach
+machop
+morpeko v
+wooper
+lt. surge's rattata
+lycanroc gx
+koga's zubat
+gothita
+unown [r]
+onix
+corsola
+scraggy
+m rayquaza ex
+deino
+garchomp
+psyduck
+meloetta
+team magma ball
+ralts
+lapras
+terrakion
+excadrill ex
+alolan diglett
+skarmory ex
+battle frontier
+react energy
+meowth
+totodile
+crystal shard
+stunfisk
+wooper
+trapinch δ
+alolan marowak
+unown [u]
+latios ex
+poké ball
+trapinch
+pinsir
+landorus
+lycanroc
+wingull
+patrat
+charizard spirit link
+xerneas break
+aron
+vullaby
+chansey
+magnemite
+drake's stadium
+zweilous
+vulpix
+double colorless energy
+minccino
+mudsdale
+alolan rattata
+ponyta
+slowpoke
+diglett
+energy retrieval
+fossil egg
+surskit
+lost remover
+morpeko vmax
+reversal trigger
+fiery flint
+aerodactyl
+pikachu
+gothorita
+treecko
+gliscor
+alolan raichu
+marowak
+pancham
+team magma belt
+alolan grimer
+spinarak
+roselia
+mr. stone's project
+lt. surge's pikachu
+shuppet
+shaymin ex
+mawile
+lickitung
+eevee
+ponyta
+sealeo
+diancie ◇
+bidoof
+sceptile spirit link
+abra
+imposter oak's revenge
+remoraid
+lucario
+mareep
+meloetta
+spoink
+ralts
+gengar
+team rocket's trickery
+electabuzz
+pawniard
+jigglypuff
+ferrothorn
+lysandre
+pluspower
+regirock
+sandshrew
+arcanine ex
+poochyena
+lt. surge's spearow
+kakuna
+kartana gx
+alolan dugtrio
+whimsicott
+turtwig
+clefable
+shroomish
+scrafty
+tyranitar spirit link
+salazzle
+timburr
+gothitelle
+psyduck
+pokémon center lady
+rattata
+rockruff
+team magma conspirator
+poochyena
+nightly garbage run
+patrat
+koffing
+rayquaza ex
+groudon
+unown [v]
+pawniard
+lost world
+bisharp
+root fossil lileep
+duskull
+lairon
+skorupi
+skitty
+cinccino
+pangoro
+warp energy
+dedenne
+natu
+snubbull
+escavalier
+swinub
+hyper devolution spray
+stakataka gx
+wurmple
+wigglytuff
+full heal
+charmeleon
+meowth
+mudbray
+magnemite
+nuzleaf
+dangerous energy
+buried fossil
+ferrothorn
+jynx
+snorlax
+curse powder
+hydreigon
+gastly
+makuhita
+kirlia
+energy recycle system
+devolution spray
+minior
+darkness energy
+switch raft
+alolan raticate
+trapinch δ
+lt. surge's rattata
+virizion
+double full heal
+swablu
+flaaffy
+galarian ponyta
+oran berry
+terrakion
+plusle
+regirock
+druddigon
+pokémon circulator
+armaldo ex
+sandslash
+magnetic storm
+snorunt
+nidorino
+lt. surge's voltorb
+drowzee
+seel
+exeggcute
+wooper
+lotad
+solrock
+seedot
+shaymin ex
+alolan muk
+psyduck δ
+bronzor
+swablu
+dawn stadium
+beginning door
+dratini
+silver bangle
+goop gas attack
+gardevoir gx
+ampharos
+klink
+dual ball
+pidove
+maintenance
+porygon
+gallade
+cleffa
+silver mirror
+slugma
+landorus
+seel
+golett
+mudsdale
+metapod
+watchog
+balloon berry
+pupitar
+cubone
+honedge
+alolan meowth
+rare candy
+wynaut
+lycanroc
+unown [w]
+ultra necrozma gx
+banette ex
+groudon
+shellos east sea
+registeel
+metal energy
+vulpix δ
+gastly
+terrakion
+palossand gx
+xatu
+energy retrieval
+electabuzz
+tyranitar
+aggron
+croconaw
+team magma hideout
+spheal
+pokénav
+galarian rapidash
+krabby
+voltorb
+taillow
+glameow
+shiftry
+sleep!
+ralts
+reshiram
+xerneas
+bisharp
+magnemite
+trapinch
+bill
+bench shield
+ruin wall
+spinarak
+lugia
+cilan
+gurdurr
+flash energy
+murkrow
+entei gx
+hypno
+deino
+pal pad
+raichu
+swinub
+misty's goldeen
+surskit
+skitty
+dragonair
+buizel
+professor elm's training method
+xerneas
+clefairy
+dusk ball
+lt. surge's voltorb
+snover
+energy recycle system
+goomy
+klink
+energy removal 2
+mareep
+pokémon fan club
+energy switch
+klang
+taillow
+alolan persian
+zweilous
+golurk
+buffer piece
+energy removal 2
+unown [y]
+raikou
+super scoop up
+holon circle
+gastly
+starly
+delibird
+cobalion
+ralts
+staryu
+nidoran ♀
+tranquill
+lillipup
+meloetta
+stantler
+professor birch
+doublade
+buzzwole
+passimian
+chansey
+diancie
+sceptile ex
+copycat
+mewtwo gx
+ultra ball
+goldeen
+shellos west sea
+marowak
+duskull
+honchkrow
+klang
+wooper
+groudon ex
+misty's horsea
+energy restore
+dustox ex
+pikachu
+sandshrew
+latios gx
+dragonite
+pokémon center lady
+minior
+grimer
+scyther
+tentacool
+full heal
+clefairy
+espeon
+lugia break
+sunkern
+dragonair
+registeel ex
+lunatone
+dwebble
+misdreavus
+palkia
+pluspower
+energy ark
+magneton
+galarian corsola
+wingull
+misty's horsea
+wooper δ
+professor oak's new theory
+rainbow energy
+shellder
+alolan exeggutor gx
+koffing
+deino
+sylveon gx
+raticate g
+revitalizer
+geodude
+team magma technical machine 01
+sliggoo
+darkrai ex
+buffer piece
+glacia's stadium
+unfezant
+full heal energy
+maintenance
+umbreon gx
+flygon ex
+weezing
+hoothoot
+seadra
+zweilous
+galarian cursola
+growlithe
+misty's magikarp
+research record
+hydreigon
+dusclops
+zekrom
+crustle
+pokémon breeder
+spiritomb
+houndoom
+exp. share
+primal groudon ex
+sudowoodo
+energy recycle system
+surskit
+swinub
+jirachi gx
+probopass
+altaria gx
+plasma energy
+marshadow gx
+unown [?]
+m sceptile ex
+grimer
+klinklang
+snorlax
+marowak break
+torchic
+poochyena
+energy root
+aegislash
+nosepass
+magnezone
+chikorita
+department store girl
+whismur
+lillipup
+goodra
+sableye
+kingdra
+energy switch
+electabuzz
+relicanth
+buffer piece
+torchic
+dedenne
+pokémon center
+mewtwo
+warp point
+haunter
+wurmple
+sandshrew
+crobat
+diglett
+darkrai
+seedot
+pangoro
+pachirisu
+memory berry
+venonat
+slowpoke
+nidoran ♂
+croagunk
+potion energy
+absol
+aegislash
+pokémon fan club
+unfezant
+onix
+gengar
+tentacool
+misty's poliwag
+totodile
+piplup
+alolan rattata
+energy switch
+dialga
+herdier
+entei gx
+seaking
+energy restore
+mew ex
+hippopotas
+noivern gx
+rare candy
+red card
+misty's poliwag
+mienfoo
+luvdisc
+conkeldurr
+mewtwo
+high pressure system
+kingdra
+sage's training
+milcery
+rhydon
+champions festival
+volbeat
+misty's determination
+hydreigon break
+flaaffy
+klinklang
+morelull
+g booster
+copycat
+clefable
+latias ex
+machop
+shieldon
+seedot
+hydreigon
+raichu
+machop
+swinub
+durant
+alolan rattata
+sigilyph
+zubat
+pokémon flute
+jangmo o
+spearow
+giratina
+dusknoir
+spheal
+trapinch δ
+aqua energy
+pawniard
+loudred
+escavalier
+balloon berry
+holon legacy
+fluffy berry
+darkrai ex
+misty's seel
+alolan raticate
+altaria
+metagross
+zubat
+mew
+hoppip
+pokédex
+alolan raticate gx
+drifloon
+great ball
+heavy ball
+dark raichu
+shroomish
+holon adventurer
+togepi
+scizor ex
+wobbuffet v
+hakamo o
+expert belt
+stoutland
+jigglypuff
+voltorb
+sunkern
+low pressure system
+roserade
+pangoro
+bisharp
+sylveon
+beldum
+staryu
+stunky
+magma energy
+latias
+makuhita
+alcremie
+magnemite
+protection cube
+cyndaquil
+rotom
+ditto
+shauna
+misty's psyduck
+scizor
+walrein ex
+blitzle
+hippowdon
+latios ex
+gloom
+g scope
+fisherman
+cobalion
+paras
+mienfoo
+pangoro
+piloswine
+magnemite
+carvanha
+sandygast
+fletchling
+squirtle
+shining celebi
+kyurem ex
+meowth
+skiploom
+silvally gx
+pidgeot spirit link
+misty's seel
+munna
+pidgey
+pidove
+alolan grimer
+latios
+electrode
+master ball
+drifblim
+team flare grunt
+rayquaza ex
+level ball
+woobat
+exploud
+mysterious shard
+misty's shellder
+mary's request
+crystal shard
+drampa gx
+fossil excavator
+double rainbow energy
+ho oh gx
+chansey
+mr. briney's compassion
+holon mentor
+sacred ash
+lucky egg
+rotom
+copycat
+misdreavus
+sneasel
+scott
+regice ★
+persian
+trapinch
+rattata
+skitty
+raichu gx
+totodile
+darkness energy
+palossand
+master ball
+zorua
+pawniard
+jigglypuff
+drilbur
+beldum
+bastiodon
+poochyena
+doduo
+lanturn
+zebstrika
+yanma
+mamoswine
+yveltal gx
+shiinotic
+mankey
+spearow
+mienshao
+purrloin
+swinub
+lickitung
+unown [l]
+beldum
+full heal
+torchic
+dugtrio
+m scizor ex
+mightyena
+ampharos ex
+klefki
+smoochum
+professor oak
+sharpedo
+zacian
+kommo o
+patrat
+mankey
+pokédex
+squirtle
+swinub
+watchog
+venonat
+pikachu
+tv reporter
+alolan muk gx
+holon fossil
+pikachu
+gible
+energy charge
+slakoth
+voltorb
+turtwig gl
+wooper
+unown [s]
+treecko
+landorus ex
+team flare grunt
+fearow
+pokémon center
+graveler
+hatenna
+bisharp
+slowpoke
+moomoo milk
+poké ball
+slowking
+mewtwo gx
+regirock ★
+chansey
+skorupi
+mawile
+nidoran ♀
+musharna
+purrloin
+miltank
+aether foundation employee
+guzzlord
+tyranitar
+poké ball
+tranquill
+revive
+pokémon retriever
+island hermit
+spinarak
+mudkip
+potion
+tangela
+zoroark
+gallade spirit link
+altaria ex
+metang
+stunfisk
+m ampharos ex
+scoop up cyclone
+startling megaphone
+hippopotas
+dragonite ex
+black belt
+misty's staryu
+old amber
+raticate
+absol
+dunsparce
+diggersby
+lotad
+bronzor
+skarmory fb
+sandile
+wally's training
+blaziken ex
+steelix
+totodile
+swoobat
+pikachu
+bellsprout
+psyduck
+mom's kindness
+electrike
+wigglytuff
+mismagius
+metal energy
+sabrina's abra
+phoebe's stadium
+magmar
+old amber
+chansey
+healing scarf
+uxie
+raichu
+shining lugia
+mimikyu
+totodile
+spiritomb c
+holon lake
+vulpix
+purugly g
+unfezant
+zoroark gx
+voltorb
+eevee
+professor oak's hint
+quagsire
+poliwag
+krokorok
+gallade
+tyrogue
+skyarrow bridge
+buneary
+treecko
+marill
+durant
+virizion ex
+espurr
+poké ball
+hattrem
+staryu
+metagross gx
+grass energy
+mr. stone's project
+liepard
+umbreon
+black kyurem
+weedle
+empoleon
+ferroseed
+purrloin
+blissey
+super potion
+tyranitar
+hoopa ex
+aipom
+swablu
+pidove
+audino ex
+unown [t]
+spearow
+lady outing
+misty's staryu
+professor oak's visit
+nidoran ♂
+gible
+trick shovel
+bronzong
+sinistea
+sneasel
+cynthia
+pokénav
+double colorless energy
+cobalion
+exeggcute
+pokémon reversal
+golett
+cradily ex
+sharpedo ex
+wigglytuff
+vibrava
+porygon
+indigo plateau
+sableye
+pow! hand extension
+spiritomb
+haunter
+eevee
+registeel ★
+dedenne
+ampharos ex
+treecko
+darkness energy
+krookodile
+golurk
+rocket's admin.
+weedle
+altaria
+mareep
+entei ex
+double colorless energy
+polteageist
+hitmonlee
+heatran
+kyogre & groudon legend
+ferrothorn
+ultimate zone
+ralts
+trapinch
+landorus
+dragonite ex
+meowstic
+fire energy
+scraggy
+pikachu δ
+tranquill
+gabite
+sabrina's abra
+altaria
+master ball
+latios spirit link
+chinchou
+rocket's hideout
+zorua
+rattata
+zorua
+eevee
+machamp ex
+junk arm
+mesprit
+zoroark gx
+bill
+hatterene
+audino
+flygon
+ambipom
+old rod
+weezing
+onix
+eevee
+alolan diglett
+pokégear 3.0
+voltorb
+farfetch'd
+crawdaunt
+poké ball
+meditite
+warp point
+ultra ball
+wooper
+genesect ex
+professor birch
+weavile
+meloetta
+cobalion
+dialga gx
+ursaring
+wingull
+slowpoke
+mr. mime
+finneon
+bill's maintenance
+voltorb
+tapu koko
+probopass
+shuckle
+m audino ex
+staryu
+mr. stone's project
+white kyurem
+steelix
+revive
+sabrina's abra
+professor elm's training method
+staravia
+grass energy
+fisherman
+double rainbow energy
+liepard
+sinistea
+unown [v]
+skrelp
+whismur
+blissey
+alolan dugtrio
+zoroark
+aaron's collection
+girafarig
+guzma
+pokémon collector
+professor cozmo's discovery
+kyogre & groudon legend
+windstorm
+dragalge
+audino
+chinchou
+flabébé
+gabite
+mime jr.
+dome fossil
+seeker
+energy removal
+arcade game
+charizard ex
+rufflet
+zeraora gx
+spritzee
+solgaleo
+celio's network
+rhyhorn
+togekiss c
+wurmple
+phanpy
+marshadow
+venonat
+voltorb
+vullaby
+indeedee v
+clefairy
+phantump
+polteageist
+slowbro spirit link
+darkrai
+jirachi ex
+zubat
+pidgey
+meteor falls
+prism energy
+raikou ex
+slugma
+golem ex
+milcery
+azelf
+geodude
+minccino
+skarmory
+starly
+remoraid
+weepinbell
+pancham
+eevee
+scizor gx
+vullaby
+unfezant
+mewtwo gx
+wailmer
+whismur
+zoroark gx
+ivysaur
+rayquaza
+rare candy
+hoothoot
+rocket's mission
+entei & raikou legend
+aggron ex
+corphish
+sabrina's drowzee
+fire energy
+noivern
+forretress
+druddigon
+sabrina's drowzee
+solgaleo ◇
+professor elm's training method
+scrafty
+energy search
+protective orb
+regigigas
+rayquaza & deoxys legend
+water energy
+murkrow
+axew
+pokémon communication
+hiker
+minccino
+bebe's search
+tyranitar ex
+metal energy
+mega turbo
+quick ball
+taillow
+scott
+energy removal 2
+wailmer
+natu
+mandibuzz
+fraxure
+misdreavus
+trevenant
+super potion
+sabrina's gastly
+donphan
+diglett
+gust of wind
+conductive quarry
+sandshrew
+claw fossil
+rayquaza spirit link
+hitmontop
+noctowl
+thundurus ex
+multi energy
+solgaleo gx
+gible
+energy switch
+dialga ex
+entei & raikou legend
+staravia
+loudred
+jynx
+xatu
+spearow
+darkrai gx
+dusk mane necrozma gx
+mandibuzz
+chatot
+marshadow & machamp gx
+sitrus berry
+braviary
+helix fossil
+m aggron ex
+clefairy
+zigzagoon
+alcremie
+diglett
+pikachu
+professor cozmo's discovery
+ancient technical machine [ice]
+lightning energy
+clefable
+haxorus
+mawile
+rocket's poké ball
+potion
+cinccino
+aromatisse
+sabrina's mr. mime
+oricorio gx
+water energy
+yanma
+ecogym
+arceus
+switch
+twins
+rayquaza & deoxys legend
+hawlucha
+weedle
+cubone
+shaymin ex
+bertha's warmth
+skarmory
+onix
+snubbull
+m tyranitar ex
+natu
+sidney's stadium
+garchomp
+giratina
+dugtrio
+flabébé
+wooper
+wingull
+lickitung
+gastly
+riolu
+scizor
+energy link
+vulpix
+potion
+professor oak's research
+sabrina's gastly
+marshadow
+lady
+magnezone ex
+sceptile ex
+pokémon reversal
+super scoop up
+kingdra ex
+gible
+audino
+minccino
+pikachu
+raikou & suicune legend
+professor elm's training method
+ponyta
+girafarig
+piplup
+exploud
+bouffalant
+palkia ex
+druddigon
+sabrina's slowpoke
+lightning energy
+energy removal 2
+space center
+nidoran ♂
+switch
+sandshrew
+clefable
+darkrai gx
+magearna
+psychic energy
+psyduck
+aipom
+miltank
+solid rage
+probopass
+exp.all
+pikachu ex
+bouffalant
+suicune ex
+garchomp
+strength charm
+rocket's tricky gym
+larvitar
+togekiss ex
+dratini
+latias ex
+alph lithograph
+revive
+staraptor
+flint's willpower
+raikou & suicune legend
+dugtrio
+ponyta
+skarmory
+double rainbow energy
+altaria ex
+phanpy
+minccino
+indeedee
+cinccino
+cacturne
+sabrina's venonat
+zubat
+professor oak's new theory
+arceus lv.x
+toxicroak ex
+broken ground gym
+deoxys ex
+swirlix
+espeon
+venusaur spirit link
+iris
+snubbull
+ancient technical machine [rock]
+floette
+rescue energy
+latias
+reshiram ex
+regigigas
+mimikyu
+giratina ex
+psychic energy
+gligar
+sabrina's gastly
+warp point
+steven's advice
+strength charm
+cover fossil
+kadabra
+beldum
+mysterious fossil
+cresselia
+klink
+aether paradise conservation area
+energy charge
+fletchling
+zigzagoon
+baltoy
+kricketot
+solrock
+lickilicky
+lillipup
+regirock
+energy switch
+pangoro
+squirtle
+shuppet
+gabite
+energy restore
+claw fossil
+latios
+excadrill
+skarmory
+tv reporter
+starmie
+cottonee
+bellsprout
+inkay
+brooklet hill
+dreepy
+exeggcute
+fighting energy
+kangaskhan ex
+pidgey
+focus band
+double colorless energy
+absol
+golbat
+swablu
+eevee
+lysandre
+cinccino
+energy switch
+lucian's assignment
+malamar
+bunnelby
+drakloak
+herdier
+klink
+zoroark
+unown
+slurpuff
+boost energy
+giratina ex
+great ball
+zorua
+drifloon
+switch
+morelull
+mt. coronet
+arceus lv.x
+sky field
+regigigas
+riolu
+lugia ex
+surprise! time machine
+spritzee
+aggron ex
+rattata
+pupitar
+swampert ex
+sandslash
+exp.all
+double full heal
+virizion
+cinccino
+florges
+skitty
+ancient technical machine [steel]
+root fossil
+rhyhorn
+whimsicott
+great ball
+excadrill
+warp point
+energy retrieval
+lugia ex
+mimikyu
+staryu
+granbull
+beldum
+switch
+kyurem ex
+yveltal
+mysterious fossil
+dome fossil
+kecleon
+fighting energy
+machoke
+latios ex
+chansey
+darkness energy
+eviolite
+cacturne ex
+sabrina's porygon
+klang
+munna
+beldum
+fletchinder
+larvitar
+double colorless energy
+blaine's quiz #1
+dual ball
+suicune & entei legend
+hoopa ex
+garchomp
+hitmonlee
+pokémon contest hall
+granbull
+slakoth
+psyduck
+celebi
+pokémon center lady
+mary
+diggersby
+ralts
+tangela
+dragapult
+holon energy ff
+kirlia
+starly
+cutiefly
+luxury ball
+dhelmise
+darkness energy
+growlithe
+chinchou
+stoutland
+togepi
+xerneas
+tyranitar
+alakazam spirit link
+suicune & entei legend
+steven
+electrode
+camerupt ex
+qwilfish
+shrine of punishment
+diglett
+klinklang
+skuntank g
+porygon z
+rufflet
+rhyhorn
+hoopa gx
+bidoof
+metang
+roselia
+lanette's net search
+vibrava
+swoop! teleporter
+pokémon fan club
+deino
+fletchling
+grass energy
+ancient tomb
+n
+dusknoir
+impostor professor oak's invention
+magby
+sylveon gx
+absol
+unown
+arceus lv.x
+darkness energy
+energy search
+honedge
+tangela
+regigigas
+talonflame
+energy search
+shiinotic
+lady outing
+fighting energy
+sabrina's psyduck
+drilbur
+metal energy
+sylveon
+blaziken ex
+magmar
+life herb
+exeggcute
+energy search
+steven
+heal energy
+raichu gx
+aromatisse
+zorua
+double colorless energy
+pokégear
+zekrom ex
+m blaziken ex
+dragapult v
+magcargo ex
+brock
+vigoroth
+musharna
+hitmonchan
+deino
+great ball
+root fossil
+sunyshore city gym
+silvally gx
+rare candy
+lucario
+rainbow energy
+buizel
+hawlucha
+holon farmer
+m charizard ex
+charity
+lum berry
+sylveon gx
+fire energy
+ralts
+venonat
+doublade
+altaria spirit link
+holon energy gl
+bulbasaur
+gengar
+zoroark
+terrakion
+desert ruins
+slaking
+rare candy
+minccino
+staravia
+dugtrio
+muk ex
+primal kyogre ex
+incineroar gx
+super energy retrieval
+venture bomb
+metal energy
+dragalge
+switch
+tapu fini
+rhyhorn
+energy switch
+alph lithograph
+helix fossil
+haxorus
+fairy energy
+blaine
+radio tower
+dedenne
+flygon
+chinchou
+m swampert ex
+slakoth
+ribombee
+kirlia
+metal energy
+furfrou
+zweilous
+deino
+tapu bulu gx
+haunter
+tapu lele
+marley's request
+metapod
+m charizard ex
+elgyem
+metagross
+mewtwo ex
+holon lass
+armor fossil shieldon
+trapinch
+seedot
+xerneas ex
+darkness energy
+torchic
+delcatty ex
+durant
+ampharos
+plume fossil
+mt. moon
+cosmog
+genesect
+magikarp
+gengar lv.x
+rufflet
+team galactic's invention g 107 technical machine g
+scramble energy
+potion
+fire energy
+gligar
+sandshrew
+jirachi
+erika
+dragapult vmax
+deoxys ex
+unown
+skarmory
+dratini
+rocky helmet
+team galactic's invention g 109 sp radar
+blissey
+lt. surge
+poké blower +
+exploud ex
+m kangaskhan ex
+chespin
+metal energy
+wally's training
+salamence lv.x
+buneary
+island cave
+poké drawer +
+leafeon
+trainers' mail
+heracross
+underground expedition
+zygarde
+beheeyem
+time capsule
+dusclops ex
+captivating poké puff
+patrat
+rattata
+groudon ex
+misty
+tornadus ex
+multi energy
+tangrowth lv.x
+call energy
+dragonair
+aegislash
+geodude
+crobat ex
+squirtle
+regigigas ex
+zweilous
+registeel
+deoxys
+brock's protection
+claw fossil
+doduo
+cubone
+marshadow
+vibrava
+poké ball
+black kyurem
+pikachu
+gligar
+dark metal energy
+rayquaza ex
+staraptor
+az
+cosmog
+braviary
+wobbuffet
+shinx
+tapu fini gx
+chikorita
+multi energy
+rattata
+voltorb
+seel
+audino spirit link
+galarian farfetch'd
+murkrow
+primal groudon ex
+gardevoir gx
+pidgeotto
+holon mentor
+water energy
+donphan
+grass energy
+oran berry
+full heal
+darkness energy
+hydreigon
+super rod
+durant
+comfey
+jirachi
+holon energy wp
+alolan exeggutor
+machamp
+treecko
+zoroark break
+rhyhorn
+klefki
+cinccino
+thought wave machine
+wash rotom
+goomy
+volkner's philosophy
+gloom
+darkness energy
+shroomish
+lightning energy
+hoopa
+swablu
+dragonite
+metal energy
+dark metal energy
+mr. mime
+watchog
+rhydon
+inkay
+bagon
+deoxys ex
+tornadus
+psychic energy
+slowpoke
+claw fossil anorith
+spearow
+doduo
+lightning energy
+graveler
+health energy
+poké healer +
+boost energy
+bronzor
+rockruff
+honedge
+xerneas gx
+sentret
+pokédex handy909
+black kyurem ex
+dodrio
+flareon
+no removal gym
+raticate
+unown [l]
+tapu koko gx
+bent spoon
+r energy
+skorupi
+holon research tower
+gible
+tauros
+champions festival
+life herb
+ponyta
+mysterious fossil
+darkness energy
+galarian sirfetch'd
+medicham ex
+xtransceiver
+lucario
+girafarig
+poliwhirl
+feraligatr
+emboar
+boost energy
+black kyurem ex
+pluspower
+cobalion ex
+jirachi ◇
+sliggoo
+tornadus
+jirachi ex
+hoothoot
+yveltal
+cheren
+charmander
+trainers' mail
+counterattack claws
+rhyperior
+nidoran ♀
+tornadus ex
+vulpix
+cyclone energy
+battle compressor team flare gear
+marill
+dialga
+flygon
+bill's teleporter
+magnezone
+zweilous
+chaos gym
+gloom
+cosmoem
+diancie
+poké ball
+δ rainbow energy
+m rayquaza ex
+bunnelby
+charmander
+chatot
+charmeleon
+the rocket's training gym
+pupitar
+poké ball
+solrock
+houndour
+golem
+bronzong
+torchic
+drowzee
+cherubi
+energy retrieval
+sudowoodo
+gardevoir spirit link
+spearow
+lunala
+white kyurem ex
+shinx
+shellder
+gulpin
+raticate break
+goomy
+nosepass
+warp energy
+cutiefly
+diggersby
+pokémon reversal
+noibat
+fearow
+chandelure
+meganium
+tapu lele gx
+fighting energy
+δ rainbow energy
+shedinja
+chaos tower
+pokémon reversal
+metal energy
+holon researcher
+paras
+card flip game
+bianca
+honedge
+metal energy
+goodra
+sneasel
+deoxys ex
+hydreigon
+kyogre ex
+charizard
+weedle
+gible
+root fossil
+milotic ex
+heatran
+float stone
+dimension valley
+erika's kindness
+volbeat
+ultra ball
+white kyurem
+sableye
+rocket's articuno ex
+azumarill
+cyclone energy
+mew
+virizion
+tauros
+bronzor
+crawdaunt ex
+entei
+lycanroc
+vaporeon
+psychic energy
+charmeleon
+premier ball
+magnetic storm
+blaine's last resort
+heatran
+druddigon
+dark claw
+energy amplifier
+sp energy
+victini
+drampa
+kangaskhan
+ferroseed
+flareon ex
+brock's training method
+azumarill
+meditite
+wally
+recover energy
+holon ruins
+doublade
+ferrothorn
+garchomp lv.x
+jangmo o
+gardevoir ex
+quilava
+goomy
+shellos east sea
+mew ex
+type: null
+wide lens
+solgaleo
+sableye
+pichu
+black kyurem ex
+dunsparce
+absol ex
+mudbray
+charizard
+dunsparce
+celadon city gym
+groudon
+pokédex
+gold berry
+hydreigon
+raichu ex
+celebi
+dark patch
+multi energy
+hitmonchan
+arceus
+computer search
+warp energy
+rocket's entei ex
+snorunt
+ribombee
+cheren
+squirtle
+enhanced hammer
+igglybuff
+prof. oak's research
+starly
+pokénav
+typhlosion
+glaceon
+chimchar
+holon scientist
+giovanni
+terrakion
+torkoal
+zoroark
+upper energy
+steven's advice
+water energy
+medicham
+gabite
+frozen city
+white kyurem ex
+eevee
+battle reporter
+marshadow
+deoxys ex
+sceptile ex δ
+gumshoos
+trainers' mail
+scramble energy
+greedy dice
+darkness energy
+energy stadium
+weedle
+hippopotas
+potion
+cubone
+tauros gx
+devolution spray
+lugia ex
+yanmega
+bronzong
+baltoy
+cerulean city gym
+aegislash
+morelull
+pawniard
+crushing hammer
+hitmonlee
+trevenant
+froslass
+professor birch
+giovanni's last resort
+glaceon lv.x
+pikachu
+miracle berry
+holon transceiver
+mightyena ex
+mr. mime
+giratina
+imposter professor oak
+pikachu
+swablu
+hakamo o
+silvally gx
+blissey ex
+cobalion
+altaria ex δ
+mareanie
+arceus
+chingling
+shellos west sea
+aipom
+mudsdale
+blacephalon
+shiinotic
+rattata
+bisharp
+alakazam e4 lv.x
+jolteon
+barboach
+stunky
+taillow
+shiftry ex
+garchomp
+sliggoo
+regice ex
+hydreigon
+great ball
+hippowdon
+hariyama ex
+dome fossil kabuto
+jigglypuff
+lucky stadium
+turtwig
+switch
+whismur
+winona
+stantler
+enhanced hammer
+super scoop up
+exeggcute
+ho oh legend
+ho oh
+tentacool
+hitmontop
+pokémon communication
+celesteela
+gengar spirit link
+marowak
+claydol ex
+ghetsis
+white kyurem ex
+rocket's hitmonchan ex
+m gardevoir ex
+baltoy
+erika's maids
+darkrai & cresselia legend
+energy switch
+groudon ex
+metal energy
+aerodactyl ex
+ninja boy
+wartortle
+eevee
+floatzel gl lv.x
+erika's perfume
+raichu
+horsea
+kingdra
+espeon
+energy search
+snubbull
+regirock ex
+cyclone energy
+pikachu
+master ball
+flygon ex
+gyarados ★ δ
+kadabra
+double dragon energy
+shadow triad
+rocket's mewtwo ex
+toxapex
+rhyhorn
+remoraid
+claydol
+arceus
+kyogre ex
+noivern gx
+raticate
+fairy energy
+onix
+fighting stadium
+super scoop up
+ho oh ex
+umbreon
+vulpix
+dragonite ex δ
+kingdra
+rhyperior v
+turtwig
+sigilyph gx
+umbreon
+metagross ex
+kakuna
+goodra
+clefairy
+hand scope
+swampert ex
+superior energy retrieval
+item finder
+ho oh legend
+salandit
+exeggcute
+kommo o gx
+cobalion gx
+manectric ex
+rhyhorn
+dialga gx
+energy pouch
+good manners
+magnifier
+pokémon ranger
+combee
+mimikyu
+whiscash
+vs seeker
+voltorb
+minccino
+metagross ex
+espeon ex
+houndour
+kyogre
+darkrai & cresselia legend
+thundurus ex
+max potion
+leafeon lv.x
+counter catcher
+granbull
+potion
+koga
+dedenne
+potion
+kartana
+flygon lv.x
+hooligans jim & cas
+swellow
+coalossal v
+mewtwo ★
+aggron ex
+abra
+wingull
+registeel ex
+regirock v
+ambipom
+new pokédex
+eevee
+sandshrew
+arceus
+warp energy
+rocket's moltres ex
+n
+shroomish
+lt. surge's treaty
+vibrava
+ledyba
+corphish
+aerodactyl ex
+diggersby
+salamence ex
+rocket's scizor ex
+rhydon
+vulpix
+potion
+honedge
+gardevoir ex
+m aerodactyl ex
+lugia
+shuckle
+palkia gx
+lt. surge's secret plan
+switch
+gallade e4 lv.x
+palkia & dialga legend
+passimian
+meowth
+energy reset
+pikachu ★
+n
+focus sash
+meowth
+wobbuffet
+rayquaza ex
+stakataka gx
+potion
+pokémon catcher
+salazzle
+arceus
+bulbasaur
+mudbray
+ultra necrozma gx
+head ringer team flare hyper gear
+slakoth
+m venusaur ex
+team plasma badge
+lileep
+seel
+goldeen
+wurmple
+yamask
+chansey
+cinccino
+minion of team rocket
+porygon z lv.x
+clefable
+pokémon personality test
+galarian yamask
+skitty
+grass energy
+professor juniper
+zygarde
+lucario gx
+feraligatr ex
+dusknoir lv.x
+flygon ex δ
+ralts
+lugia legend
+flygon
+eevee
+alakazam ★
+special charge
+glameow
+spinda
+zigzagoon
+lass
+wurmple
+nosepass
+gallade ex
+dashing pouch
+professor elm
+croagunk
+lapras
+ninetales ex
+coalossal vmax
+zigzagoon
+dawn wings necrozma gx
+fire energy
+bulbasaur
+kabutops ex
+blissey
+galarian runerigus
+misty's wrath
+druddigon
+vigoroth
+lickitung
+salamence ex
+celebi ★
+flabébé
+gulpin
+shiftry ex
+team plasma ball
+farfetch'd
+rocket's scyther ex
+sprout tower
+weedle
+trapinch
+pokémon breeder
+revive
+aerodactyl spirit link
+fossil researcher
+steelix spirit link
+doduo
+old amber aerodactyl
+champions festival
+linoone
+arceus ◇
+floette
+ditto
+sharpedo ex
+m gallade ex
+super scoop up
+recycle
+gardevoir ex δ
+switch
+m charizard ex
+team rocket's evil deeds
+lickilicky
+devoured field
+hippowdon lv.x
+purugly
+cofagrigus
+palkia & dialga legend
+bagon
+pewter city gym
+skarmory ex
+ledyba
+jamming net team flare hyper gear
+raichu ex
+rhyperior
+water energy
+dusk mane necrozma gx
+binacle
+amulet coin
+lillipup
+switch
+shuppet
+darkness energy
+arceus
+doublade
+broken time space
+cosmog
+palkia
+double full heal
+clobbopus
+mudsdale
+slaking
+caterpie
+shinx
+jirachi
+ho oh ex
+rocket's sneasel ex
+heatran lv.x
+grass energy
+bouffalant
+delcatty
+taillow
+regice ex
+plasma energy
+galarian sirfetch'd
+lugia legend
+grimer
+doduo
+fairy drop
+meowth
+misty's wish
+meowth
+infernape e4 lv.x
+swellow
+lunala gx
+misdreavus
+espurr
+latias ★
+multi energy
+swablu
+fighting memory
+drifloon
+fairy garden
+herdier
+arceus
+life dew
+metal energy
+lightning energy
+tornadus ex
+latios ex
+pokémon trader
+super scoop up
+bidoof
+spinda
+slakoth
+charmander
+litwick
+aegislash
+barbaracle
+walrein ex
+full heal
+nincada
+galarian slowbro v
+snorlax
+castform
+florges
+felicity's drawing
+switch
+heal powder
+trapinch
+swablu
+alph lithograph
+klefki
+volcanion ex
+regirock ex
+silicobra
+dodrio
+tornadus
+arceus
+persian
+fossil excavation kit
+rock guard
+skitty
+furfrou
+luxray gl lv.x
+growlithe
+wooper
+lugia ex
+cyrus's conspiracy
+feebas
+bunnelby
+energy restore
+rolycoly
+ledyba
+resistance gym
+necrozma
+stoutland
+lysandre's trump card
+grass energy
+darkness energy
+grapploct
+m blastoise ex
+bibarel
+eevee
+rocket's snorlax ex
+lunala gx
+snorunt
+typhlosion ex
+rainbow energy
+lampent
+recall
+blastoise ex
+eevee
+psychic energy
+kingdra ex δ
+latios ★
+squirtle
+meowstic
+berry
+mewtwo
+gladion
+machamp lv.x
+bagon
+scoop up
+charmander
+m latios ex
+flareon ★
+fire energy
+professor juniper
+full heal energy
+thundurus
+raikou
+rayquaza ★
+jaw fossil
+holon energy ff
+stantler
+helix fossil omanyte
+zamazenta
+mew
+solgaleo gx
+galactic hq
+grass energy
+meganium ex
+mail from bill
+rocket's suicune ex
+energy switch
+charizard ex
+fighting energy
+wailord ex
+bianca
+fire energy
+chansey ex
+porygon
+alolan ninetales
+quagsire
+registeel ex
+lillipup
+all night party
+mismagius gl lv.x
+bidoof
+shining celebi
+chikorita
+arceus
+cedric juniper
+yveltal
+electabuzz ex
+solgaleo gx
+gligar
+mimikyu
+holon energy gl
+latias ex δ
+geodude
+porygon2
+steelix ex
+silicobra
+sunkern
+sabrina
+level max
+machop
+hydreigon ex
+snover
+grimer
+rayquaza
+poipole
+togepi
+super energy removal
+florges break
+vibrava
+manectric spirit link
+lusamine
+raichu lv.x
+jolteon ★
+herdier
+korrina
+shelgon
+fire energy
+lass's special
+carkol
+snorlax
+water energy
+clefable ex
+rocket's zapdos ex
+random receiver
+chandelure
+rocket's raikou ex
+mewtwo ex
+heatran ex
+politoed ex
+nosepass
+pikipek
+tornadus
+night pokémon center
+double gust
+hitmonchan
+bursting balloon
+poochyena
+mewtwo
+rayquaza
+water energy
+potion energy
+vileplume ex
+eevee
+sabrina's esp
+delcatty
+farfetch'd
+diggersby
+leftovers
+genesect
+hitmonchan ex
+holon energy wp
+electrode ex
+stoutland
+trapinch
+lycanroc
+moonlight stadium
+aurorus ex
+pidgeot ex
+crushing hammer
+blaine's quiz #2
+delinquent
+gliscor
+spinda
+professor sycamore
+furfrou
+hitmontop
+scizor ex
+sandaconda
+regigigas lv.x
+m steelix ex
+dunsparce
+togepi
+pokémon breeder
+rayquaza ex
+vaporeon ★
+onix
+mega catcher
+salamence
+meloetta
+magearna ex
+togetic
+gengar ex
+gible
+charmander
+suicune
+rare candy
+energy switch
+bibarel
+venonat
+mareanie
+moo moo milk
+snorlax lv.x
+water energy
+muk
+life herb
+grass energy
+trumbeak
+mightyena
+pokémon trader
+m pidgeot ex
+secret mission
+pluspower
+maintenance
+taillow
+steelix ex
+wigglytuff ex
+robo substitute team flare gear
+buneary
+mudkip ★
+mawile ex
+latias & latios gx
+coalossal
+hoppip
+flygon gx
+flabébé
+m rayquaza ex
+noibat
+steelix
+numel
+latias ◇
+bunnelby
+patrat
+thundurus ex
+defender
+bidoof
+spritzee
+chikorita
+sandaconda
+lightning energy
+metal energy
+delinquent
+blaine's quiz #3
+porygon z
+latios ex δ
+premier ball
+dawn wings necrozma
+n
+magikarp
+spheal
+shining charizard
+lapras ex
+tyrogue
+peeking red card
+lightning energy
+n
+dusk mane necrozma
+skitty
+scoop up
+double colorless energy
+diggersby
+typhlosion ex
+groudon
+gyarados ex
+bidoof
+sandaconda v
+delinquent
+psychic energy
+twist mountain
+m mawile ex
+lopunny
+torchic ★
+flareon ex
+floette
+hitmontop
+looker's investigation
+energy retrieval
+rare candy
+lightning energy
+deoxys ex
+charmeleon
+togekiss
+spinarak
+cinnabar city gym
+clefairy
+pokémon march
+sableye
+psychic memory
+magmar ex
+the boss's way
+drapion v
+n
+audino
+treecko ★
+whismur
+mawile spirit link
+cubone
+latias ex
+poké ball
+nihilego
+roller skates
+noivern
+ariados
+fighting fury belt
+sea of nothingness
+bibarel
+super rod
+latios ◇
+reshiram
+voltorb
+falinks
+shaymin ex
+glameow
+clobbopus
+dragonite ex
+spinarak
+swirlix
+psychic energy
+delcatty
+ultra ball
+genesect
+jolteon ex
+oddish
+magnemite
+mr. mime ex
+alolan exeggutor
+mewtwo ex
+horsea
+fuchsia city gym
+memory berry
+charizard
+rayquaza ex δ
+porygon z
+toucannon
+fire energy
+fighting energy
+aromatisse
+ash's pikachu
+gardevoir ex
+tickling machine
+corsola
+watchog
+psychic energy
+riolu
+mountain ring
+anorith
+shining kabutops
+full heal
+cresselia lv.x
+fletchling
+tyranitar ex
+goldeen
+pikachu
+zekrom
+water energy
+vaporeon ex
+bouffalant
+great ball
+poipole
+landorus
+wooper
+cubone
+m gardevoir ex
+furfrou
+spinda
+sail fossil
+fighting energy
+scyther ex
+old amber aerodactyl
+hoothoot
+fletchling
+drifloon
+umbreon ex
+miasma valley
+slurpuff
+shining mewtwo
+rayquaza gx
+mantine
+xerneas
+snivy
+maintenance
+lightning energy
+sparkling robe
+darkness energy
+darkness energy
+fletchinder
+falinks v
+bebe's search
+aerodactyl gx
+naganadel
+dunsparce
+duskull
+surskit
+horsea
+fighting energy
+pokémon ranger
+sylveon ex
+pluspower
+koga's ninja trick
+challenge!
+purugly
+meowth
+cyndaquil
+ash's pikachu
+super scoop up
+noctowl
+entei ex
+darkrai lv.x
+cassius
+wally
+brock's grit
+vermilion city gym
+shauna
+talonflame
+charmeleon
+armaldo
+axew
+darkness energy
+metal energy
+clobbopus
+gyarados ex
+beast ring
+stonjourner
+buneary
+pokédex handy910is
+sandile
+yungoos
+servine
+pokémon fan club
+counter energy
+pluspower
+crobat v
+shining noctowl
+entei ★
+sneasel ex
+latios ex
+bunnelby
+mr. mime ex
+salamence ex δ
+crabrawler
+groudon ★
+gyarados spirit link
+alolan exeggutor
+flying pikachu
+minccino
+metal energy
+growlithe
+oddish
+loudred
+psychic energy
+blaine's gamble
+fighting energy
+diancie
+pokémon center
+steel shelter
+kyogre ★
+onix
+reshiram
+professor sycamore
+lopunny
+dratini
+energy retrieval
+tool retriever
+teddiursa
+night maintenance
+max elixir
+exploud
+crabominable
+tyranitar ex δ
+pineco
+surfing pikachu
+gyarados
+misty's determination
+heracross
+mew
+bouffalant
+houndour
+kricketot
+cyndaquil
+koffing
+bouffalant
+krokorok
+serperior
+pokédex
+krookodile
+metagross ★
+galarian weezing
+ash's pikachu
+tornadus ex
+recycle energy
+dratini
+noibat
+groudon
+volcanion ex
+fan rotom
+target whistle team flare gear
+darkrai
+beast ring
+energy flow
+voltorb
+master ball
+fan rotom
+swablu
+max potion
+power memory
+grass energy
+ナッシー[exeggutor]
+winona
+professor rowan
+shining raichu
+evosoda
+gyarados gx
+poké ball
+raikou ★
+patrat
+lugia ex
+kyogre ex
+totodile
+charizard ★ δ
+venusaur ex
+breloom
+murkrow
+sudowoodo
+alph lithograph
+stakataka
+bill
+training center
+magikarp
+grapploct
+wingull
+here comes team rocket!
+stufful
+houndour
+gumshoos gx
+zekrom
+bunnelby
+axew
+mewtwo ex
+poliwag
+dialga lv.x
+rufflet
+pluspower
+growlithe
+diglett
+dragonair
+misty's determination
+ash's pikachu
+poliwhirl
+vulpix
+altaria
+acro bike
+magnemite
+rival
+misty's duel
+professor oak's visit
+drilbur
+palkia lv.x
+stunky
+bonnie
+shaymin
+herbal energy
+greninja & zoroark gx
+max revive
+raikou ex
+mysterious fossil
+bewear
+gardevoir ex
+fighting energy
+charmander
+mew ★ δ
+frost rotom
+trubbish
+azumarill
+suicune ★
+ghetsis
+phanpy
+stonjourner
+stufful
+misty's tears
+dratini
+dragonite
+watchog
+professor juniper
+murkrow
+strong energy
+professor rowan
+skitty
+zubat
+natu
+fighting energy
+alolan golem gx
+stufful
+stonjourner v
+donphan
+skuntank
+mankey
+fire energy
+articuno ex
+kangaskhan
+purrloin
+ash's pikachu
+pelipper
+heat rotom
+meditite
+machamp ex
+pikachu
+komala
+random receiver
+braviary
+fletchling
+poochyena
+flying pikachu
+pokémon catcher
+narrow gym
+tierno
+rocket's persian ex
+torchic
+shining steelix
+fairy garden
+fraxure
+garbodor
+crasher wake
+excadrill
+aggron spirit link
+potion
+yungoos
+professor oak
+energy switch
+bewear
+groudon ex
+pokédex handy910is
+speed stadium
+drampa gx
+riolu
+archie's ace in the hole
+trick coin
+diantha
+eevee & snorlax gx
+ash's pikachu
+pokémon rescue
+meditite
+spiritomb
+sabrina's gaze
+gyarados
+super potion
+rocket's minefield gym
+super scoop up
+mow rotom
+darkrai ex
+gumshoos
+shining tyranitar
+ekans
+empoleon
+bewear
+heracross ex
+moltres ex
+surfing pikachu
+patrat
+potion
+floral crown
+galarian meowth
+liepard
+larvitar
+rival
+devolution spray
+slakoth
+honchkrow gx
+vs seeker
+medicham
+hitmontop
+bebe's search
+piplup
+sigilyph
+lillipup
+deino
+nihilego gx
+gastly
+trubbish
+ash's pikachu
+great ball
+pidgey
+lickitung
+bill
+roseanne's research
+zapdos ex
+giant cape
+professor sycamore
+scorched earth
+oranguru
+mew
+aether paradise conservation area
+wash rotom
+shinx
+imakuni?'s doduo
+water energy
+team galactic's invention g 101 energy gain
+celebi ex
+acerola
+warp point
+dive ball
+eneporter
+rocket's secret experiment
+nidoran ♀
+tornadus ex
+stonjourner vmax
+wally
+haxorus
+patrat
+galarian perrserker
+carvanha
+vs seeker
+trash exchange
+dusk ball
+larvitar
+palpitoad
+pikachu
+grass energy
+oranguru
+meowth
+vigoroth
+relicanth
+seismitoad ex
+energy search
+mime jr.
+unown
+team galactic's invention g 103 power spray
+celebi
+geodude
+lightning energy
+pidgey
+garbodor
+fossil excavator
+team galactic's mars
+altar of the moone
+skitty
+fossil excavation map
+larvitar
+seismitoad
+energy retrieval
+acerola
+professor sycamore
+fighting energy
+xerosic
+sharpedo
+watchog
+magnemite
+garbodor
+type: null
+gardevoir
+charon's choice
+pheromosa
+big malasada
+ralts
+energy removal
+gible
+zweilous
+forretress
+sabrina's psychic control
+noivern
+slaking
+buzzwole gx
+flareon ex
+rescue scarf
+galarian zigzagoon
+lucario ex
+shauna
+here comes team rocket!
+herdier
+double colorless energy
+altar of the sunne
+gabite
+galarian linoone
+potion
+mudkip
+pikachu
+hard charm
+psychic energy
+team galactic's invention g 105 poké turn
+nidoran ♀
+guzzlord gx
+fire energy
+vullaby
+jirachi
+dragonite ex
+watchog
+tool scrapper
+judge
+sneasel
+stoutland
+spiritomb
+unown
+whismur
+silvally gx
+psychic energy
+noivern break
+saffron city gym
+steelix v
+xurkitree
+garchomp
+hydreigon
+lake boundary
+psychic's third eye
+escape rope
+kirlia
+pupitar
+shauna
+throh
+gust of wind
+bodybuilding dumbbells
+pidgeotto
+archeops
+potion
+goldeen
+mankey
+crushing hammer
+malamar
+meowth
+pidgeot
+spoink
+aqua patch
+exp. share
+grass energy
+nincada
+carbink
+garchomp
+bouffalant
+energy retrieval
+night maintenance
+pancham
+mystery energy
+whismur
+switch
+manaphy
+escape rope
+pokémon catcher
+sandile
+gardevoir ex
+viridian city gym
+water energy
+fire energy
+mareep
+team rocket's handiwork
+mandibuzz
+hoppip
+armor fossil
+unown
+gardevoir
+pidove
+switch
+drampa
+blend energy grassfirepsychicdarkness
+hoopa
+beldum
+battle reporter
+puzzle of time
+max potion
+kartana gx
+darkrai
+energy switch
+sandile
+manectric ex
+doduo
+miltank
+fossil researcher
+loudred
+m gardevoir ex
+meloetta ex
+ultra ball
+ultra ball
+lightning energy
+guzma
+fervor
+alolan meowth
+rufflet
+unown
+quick ball
+nickit
+blend energy waterlightningfightingmetal
+poké ball
+pangoro
+reverse valley
+riolu
+skull fossil
+nidorina
+empoleon lv.x
+alolan exeggutor gx
+ancient crystal
+max revive
+meowth
+darkness energy
+metang
+lycanroc
+galarian obstagoon
+pachirisu
+staryu
+fresh water set
+lightning energy
+brooklet hill
+lady
+houndour
+tranquill
+malamar v
+gardevoir spirit link
+exeggcute
+psychic energy
+crabrawler
+exp. share
+swinub
+muscle band
+gengar ex
+shaymin
+lysandre ◇
+ho oh ex
+rainbow energy
+persian
+paras
+braviary
+doduo
+unfezant
+choice band
+transparent walls
+silvally gx
+metagross
+malamar vmax
+sableye v
+alolan persian
+koffing
+cynthia
+mr. mime
+korrina
+sylveon ex
+double colorless energy
+metal energy
+riolu
+guzma
+scizor spirit link
+unown
+potion
+exploud
+infernape lv.x
+team galactic's wager
+thievul
+krokorok
+pikachu
+stunfisk
+groudon spirit link
+great ball
+water energy
+malamar ex
+crabominable
+taillow
+rockruff
+gladion
+krookodile
+warp point
+rockruff
+audino
+tierno
+grimmsnarl v
+dialga g lv.x
+strong energy
+m heracross ex
+torterra lv.x
+skitty
+umbreon
+armor fossil
+impidimp
+krabby
+dodrio
+skorupi
+switch
+florges ex
+arceus
+choice band
+kyogre spirit link
+farfetch'd
+jirachi
+gardevoir lv.x
+cynthia
+bicycle
+kiawe
+professor sycamore
+tentacool
+hau
+mew ex
+lucario
+unown
+lysandre labs
+nidoran ♂
+pineco
+raikou gx
+pikachu
+purrloin
+kangaskhan
+energy loto
+az
+tyrogue
+grass energy
+glaceon ex
+lucario
+zygarde gx
+skull fossil
+delcatty
+kiawe
+larvitar
+piplup
+drapion lv.x
+lycanroc
+ilima
+grimmsnarl vmax
+double colorless energy
+lusamine
+colress
+victini
+terrakion ex
+metal frying pan
+snorlax
+aspertia city gym
+fighting energy
+cyrus ◇
+drapion
+oddish
+maxie's hidden ball trick
+morgrem
+professor's letter
+drilbur
+m lucario ex
+unown
+eternatus v
+metal frying pan
+eevee
+fire energy
+machop
+fire energy
+energy recycler
+professor birch's observations
+passimian
+olivia
+onix
+energy search
+lysandre's trump card
+dialga
+tyranitar gx
+fighting energy
+kecleon
+multi energy
+registeel ex
+red card
+hoothoot
+grimmsnarl
+lillie
+greninja
+rhyhorn
+honchkrow lv.x
+croagunk
+splash energy
+pineco
+electric memory
+colress machine
+lana
+keldeo
+weepinbell
+giratina lv.x
+dawn wings necrozma
+alakazam ex
+tauros
+excadrill
+enhanced hammer
+grass energy
+nest ball
+noctowl
+rayquaza ex
+xerosic
+eternatus vmax
+roselia
+palkia g lv.x
+gyarados gx
+dusk mane necrozma
+toxicroak
+paras
+archen
+fire energy
+aerodactyl
+great ball
+mysterious treasure
+sandygast
+m alakazam ex
+water energy
+genesect
+roller skates
+excadrill
+yanma
+poliwag
+unown
+galarian meowth
+escape rope
+inkay
+darkness energy
+rare candy
+gyarados ex
+mount lanakila
+acro bike
+escape board
+alolan diglett
+teddiursa
+magikarp
+enhanced hammer
+lightning energy
+m manectric ex
+poison barb
+teddiursa
+lugia
+naganadel gx
+lightning energy
+mysterious treasure
+giratina ex
+palossand
+grass energy
+alolan golem gx
+umbreon ex
+olivia
+ultra recon squad
+archeops
+shadow circle
+poliwhirl
+poké ball
+ursaring
+nihilego gx
+meloetta
+serperior
+metal energy
+psychic energy
+genesect ex
+nickit
+m gengar ex
+acro bike
+escape board
+ferroseed
+alolan meowth
+mareep
+sandshrew
+repeat ball
+ursaring
+scizor v
+shaymin lv.x
+unown
+bubble coat
+alolan dugtrio
+ultra necrozma gx
+psychic energy
+galarian perrserker
+hugh
+lightning energy
+malamar
+zangoose
+m gyarados ex
+phanpy
+ether
+field blower
+smeargle
+psychic energy
+water energy
+fighting energy
+pinsir
+ultra space
+buzzwole gx
+poké ball
+alolan persian gx
+thievul
+m altaria ex
+shaymin lv.x
+bill's analysis
+pokémon catcher
+buck's training
+dialga ex
+lucario & melmetal gx
+rough seas
+shauna
+plumeria
+alolan sandslash
+manaphy ex
+apricorn maker
+seel
+scizor vmax
+ferrothorn
+field blower
+charizard ex
+fire memory
+marill
+raticate
+reuniclus
+forretress
+electivire lv.x
+eviolite
+audino
+unown
+scizor
+terrakion
+darkness energy
+swablu
+water energy
+kingdra ex
+ponyta
+galarian meowth
+potion
+potion
+electabuzz
+blastoise ex
+steelix
+guzzlord gx
+hitmonchan
+porygon
+shinx
+krookodile
+scorched earth
+galarian stunfisk
+espeon ex
+galarian perrserker
+minccino
+unown
+super potion
+meloetta
+professor kukui
+beast ball
+gardenia
+meowth
+rocky helmet
+black market ◇
+bronzor
+starly
+rattata
+po town
+metal energy
+alolan diglett
+cynthia's feelings
+alolan grimer
+altaria ex
+lucario lv.x
+hypnotoxic laser
+hala
+unidentified fossil
+skarmory
+alolan ninetales
+rare candy
+shrine of memories
+energy pickup
+beast energy ◇
+kartana gx
+mallow
+kyogre
+brock's grit
+team rocket's handiwork
+lillie
+scyther
+unown
+skyla
+shroomish
+mawile
+venusaur ex
+oddish
+team flare grunt
+staravia
+darkrai ex
+rhyhorn
+bronzong
+rotom dex poké finder mode
+zygarde
+alolan dugtrio
+magmortar lv.x
+aegislash v
+aron
+bill's maintenance
+alolan muk
+psyduck
+plasma frigate
+rayquaza
+scizor
+cinccino
+poké radar
+silent lab
+unit energy fightingdarknessfairy
+repel
+manectric
+alolan exeggutor gx
+max potion
+alakazam ex
+staraptor
+lillie
+ferroseed
+buff padding
+switch
+lotad
+scizor ex
+pikachu ex
+sandshrew
+double colorless energy
+skorupi
+unown
+probopass
+dialga
+team plasma grunt
+copycat
+pidgey
+sophocles
+carvanha
+snowpoint temple
+town map
+pikachu
+time space distortion
+absol
+dana
+mewtwo ex
+chatot
+swablu
+super scoop up
+virbank city gym
+ferrothorn
+durant
+teammates
+aegislash vmax
+looker
+silvally gx
+energy recycle system
+elesa
+lairon
+umbreon & darkrai gx
+durant
+remoraid
+celesteela
+starly
+sandslash
+m scizor ex
+rotom dex
+aron
+palkia gx
+unown
+rainbow energy
+max potion
+computer search
+grass energy
+galarian stunfisk
+weakness policy
+dangerous drill
+counter catcher
+pawniard
+vulpix
+stark mountain
+switch
+rufflet
+looker whistle
+seel
+ho oh ex
+plasma energy
+mew ex
+aggron
+honedge
+mega sableye & tyranitar gx
+poliwag
+unown
+surskit
+multi switch
+delcatty
+shaymin ex
+tormenting spray
+scyther
+cobalion
+greninja gx
+lairon
+energy switch
+magearna
+shield energy
+electrocharger
+bisharp
+fire energy
+technical machine ts 1
+crystal edge
+wishful baton
+rescue stretcher
+braviary
+thundurus gx
+team skull grunt
+turtwig
+moltres
+seel
+pawniard
+unown
+ponyta
+sentret
+dowsing machine
+skyla
+doublade
+mars
+escavalier
+alolan grimer
+fisherman
+weakness policy
+genesect gx
+missing clover
+friend ball
+qwilfish
+wicke
+whismur
+counter energy
+klink
+bisharp
+scramble switch
+aggron
+duraludon
+shuckle
+tornadus gx
+unown
+gyarados ex
+slowpoke
+timer ball
+magearna
+white kyurem
+aegislash
+naganadel gx
+water energy
+guzzlord
+erika's hospitality
+noibat
+technical machine ts 2
+crystal wall
+reshiram
+wonder energy
+murkrow
+rescue stretcher
+trevenant ex
+turtonator gx
+evelyn
+mt. coronet
+rattata
+warp energy
+lightning energy
+corviknight
+wishful baton
+ultra ball
+klang
+copperajah v
+skarmory
+zygarde
+smeargle
+latias
+murkrow
+claw fossil
+unown
+noibat
+emolga
+alolan ninetales gx
+eevee
+alolan sandshrew
+lucario
+gold potion
+zubat
+hau
+lucario gx
+victory piece
+camerupt ex
+water energy
+psychic energy
+shellder
+fairy charm ub
+alolan ninetales gx
+order pad
+golisopod gx
+latios
+slugma
+double colorless energy
+tyranitar
+cufant
+copperajah vmax
+mew ex
+assault vest
+honchkrow
+celebi ex
+genesect
+battle tower
+jigglypuff
+sneasel
+unown
+klinklang
+alolan sandslash
+hiker
+root fossil
+victini ex
+snorlax
+wailord ex
+zygarde gx
+grass memory
+fighting energy
+pal pad
+wishiwashi gx
+brigette
+pansear
+duraludon
+azelf lv.x
+meltan
+darkness energy
+yveltal gx
+reshiram gx
+galarian stunfisk v
+sneasel
+keldeo ex
+copperajah
+wigglytuff
+unown
+articuno ex
+rainbow energy
+meloetta ex
+hustle belt
+lugia
+kyogre ex
+pokémon fan club
+tapu bulu gx
+vikavolt gx
+champion's room
+slugma
+spearow
+spinarak
+steelix
+ingo & emmet
+buddy buddy rescue
+jasmine
+primal kyogre ex
+tapu koko gx
+metal energy
+marill
+melmetal
+squirtle
+snorlax
+mawile
+unidentified fossil
+unown
+tangela
+lurantis gx
+zacian
+last chance potion
+taillow
+weavile gx
+dialga gx
+cresselia ex
+ho oh gx
+zekrom gx
+gastly
+cynthia's guidance
+zacian v
+cobalion ex
+gliscor lv.x
+meltan
+judge whistle
+fisherman
+groudon ex
+toxapex gx
+lapras gx
+fairy energy
+volkner
+salamence gx
+probopass
+gardevoir & sylveon gx
+tentacool
+unown
+snubbull
+squirtle
+life herb
+zamazenta
+sableye
+salazzle gx
+xerneas gx
+azumarill
+landorus ex
+lugia ex
+cyrus's initiative
+swellow
+magnezone lv.x
+melmetal
+ash greninja ex
+zamazenta v
+tapu lele gx
+salamence
+venusaur ex
+primal groudon ex
+volkner
+lavender town
+espeon gx
+float stone
+solgaleo
+snorlax
+togepi
+lisia
+unown
+tauros
+cleffa
+stantler
+black kyurem ex
+white kyurem gx
+ultra necrozma gx
+lure ball
+blastoise ex
+cufant
+clefairy
+staryu
+voltorb
+lycanroc gx
+whismur
+giovanni's scheme
+night teleporter
+tapu fini gx
+unown
+totodile
+togepi & cleffa & igglybuff gx
+mesprit lv.x
+colress
+snubbull
+metal goggles
+snorlax
+sharpedo ex
+super boost energy ◇
+lunala gx
+empoleon break
+chatot
+drapion
+morgan
+glalie spirit link
+totodile
+unown
+clefable
+metagross gx
+bonnie
+beheeyem break
+staryu
+togepi & cleffa & igglybuff gx
+palmer's contribution
+aggron ex
+kyurem
+white kyurem ex
+loudred
+granbull
+emolga ex
+copperajah
+unit energy grassfirewater
+pidove
+the masked royal
+vulpix
+umbreon gx
+necrozma gx
+mewtwo lv.x
+purrloin
+charizard
+snorlax v
+nanu
+heavy ball
+sylveon gx
+unown
+m aggron ex
+vulpix
+moltres
+jigglypuff
+crasher wake
+sunflora
+noctowl break
+clefairy
+vs seeker
+bianca
+exploud
+ralts
+yveltal ex
+unit energy lightningpsychicmetal
+tranquill
+kangaskhan
+solgaleo gx
+snorlax vmax
+liepard
+blastoise
+pokénav
+wooper
+rhyperior lv.x
+machamp gx
+wigglytuff
+nita
+gardevoir ex
+sunkern
+kommo o gx
+heavy boots
+articuno
+unown
+alolan ninetales
+diantha
+bill's maintenance
+skarmory ex
+absol g lv.x
+tauros
+vivillon
+rayquaza
+unfezant
+froakie
+rainbow brush
+swinub
+azurill
+uxie lv.x
+scraggy
+leafeon gx
+tauros gx
+random receiver
+hoothoot
+lycanroc gx
+togepi
+m gardevoir ex
+xerneas ex
+pokémon communication
+apricorn forest
+zapdos
+chatot
+drampa gx
+houndoom spirit link
+sentret
+cheren
+blaziken fb lv.x
+bunnelby
+kirlia
+unown
+ultra recon squad
+copycat
+charizard g lv.x
+judge
+archie's ace in the hole
+diggersby
+dual ball
+hala
+swinub
+togetic
+noctowl
+leafeon gx
+pokémon communication
+skyla
+marshadow gx
+scrafty
+rare candy
+gardevoir
+togekiss v
+cottonee
+furret
+darkness cube 01
+pheromosa gx
+gumshoos gx
+palkia gx
+floette
+maxie's hidden ball trick
+electivire fb lv.x
+mewtwo spirit link
+teddiursa
+hawlucha
+togekiss
+energy removal 2
+shrine of punishment
+ilima
+hau
+greninja gx
+minccino
+whimsicott
+pokémon communication
+glaceon gx
+togekiss vmax
+energy switch
+dedenne
+golurk
+yveltal
+glaceon gx
+lucario
+alolan muk gx
+dunsparce
+professor birch's observations
+garchomp c lv.x
+stufful
+parallel city
+ursaring
+lillie
+sky pillar
+champions festival
+energy restore
+mallow
+cottonee
+return label
+flabébé
+xurkitree gx
+teammates
+teddiursa
+hoopa
+minccino
+tornadus
+fighting cube 01
+rayquaza
+darkrai gx
+terrakion
+naganadel gx
+carbink
+sabrina's suggestion
+professor's letter
+fire cube 01
+professor kukui
+ursaring
+pikipek
+venomoth
+flabébé
+steven's resolve
+lucario gx
+cinccino
+suicune
+gardevoir gx
+mary's impulse
+dawn wings necrozma gx
+altaria
+decidueye gx
+rayquaza c lv.x
+mawile gx
+azelf
+whimsicott gx
+dive ball
+bewear
+xerneas ◇
+professor's letter
+enhanced hammer
+unidentified fossil
+raikou
+rocky helmet
+incineroar gx
+venonat
+magikarp
+celesteela gx
+skwovet
+noivern gx
+staraptor fb lv.x
+forest guardian
+floette
+trumbeak
+master ball
+escavalier
+cutiefly
+super scoop up
+spritzee
+team skull grunt
+lugia
+oranguru
+zygarde gx
+reserved ticket
+switch
+giratina
+viridian forest
+turtonator gx
+voltorb
+dusk mane necrozma gx
+acerola
+switch
+ribombee
+florges
+greedent
+toucannon
+articuno
+cottonee
+lurantis gx
+skitty
+grass cube 01
+yveltal gx
+yanmega
+multi technical machine 01
+drampa
+aromatisse
+weakness policy
+skyla
+tapu lele
+water memory
+primarina gx
+weedle
+dialga gx
+lapras gx
+guzma
+pokémon nurse
+volcanion
+allister
+wondrous labyrinth ◇
+moltres
+rattata
+dialga gx
+alolan ninetales gx
+rookidee
+delcatty
+dubwool v
+super rod
+whimsicott
+rowlet
+healing berry
+tate & liza
+morelull
+swirlix
+slurpuff
+xerneas gx
+bea
+celebi & venusaur gx
+espeon gx
+wishiwashi gx
+palkia gx
+raticate
+boss's orders
+kiawe
+salandit
+tate & liza
+dedenne
+salamence v
+weedle
+zapdos
+juggler
+town map
+clawitzer
+corvisquire
+pokémon reversal
+shiinotic
+lunala gx
+vikavolt gx
+kingdra gx
+magikarp & wailord gx
+yanma
+burning scarf
+milotic
+burning energy
+hoopa
+cynthia
+sylveon
+tv reporter
+spearow
+lightning cube 01
+ultra necrozma gx
+plumeria
+mimikyu gx
+power charge
+wooloo
+garchomp & giratina gx
+beauty
+salamence vmax
+tapu koko gx
+magikarp & wailord gx
+umbreon gx
+dragonite gx
+rainbow energy
+relicanth
+capacious bucket
+zubat
+beast ring
+gardenia
+memory berry
+arceus & dialga & palkia gx
+fearow
+shaymin ex
+underground expedition
+sophocles
+dratini
+wooloo
+professor elm's training method
+tapu lele
+cara liss
+starly
+toxapex gx
+solgaleo gx
+pikachu & zekrom gx
+pikachu
+houndoom ex
+zubat
+yanma
+cursed shovel
+wicke
+reshiram & zekrom gx
+rainbow energy
+xerneas ex
+metal cube 01
+eneporter
+meowth
+staravia
+dubwool
+circhester bath
+lana
+dratini
+tapu fini
+tapu lele gx
+professor oak's research
+tauros gx
+charizard
+ampharos gx
+m houndoom ex
+dan
+ancient ruins
+naganadel & guzzlord gx
+golisopod gx
+yveltal ex
+chansey
+energy recycler
+dragonair
+gumshoos gx
+zapdos
+staraptor
+lycanroc gx
+yveltal ex
+full heal
+glalie ex
+drone rotom
+drampa
+strength charm
+cramorant v
+tapu bulu gx
+pokémon fan club
+lillie
+persian
+gengar & mimikyu gx
+shiftry gx
+relic hunter
+galar mine
+jangmo o
+super scoop up
+hero's medal
+blissey
+persian gx
+apricorn maker
+metal frying pan
+gengar & mimikyu gx
+m glalie ex
+metagross gx
+nest ball
+ducklett
+blaziken gx
+charizard gx
+looker
+pokémon park
+air balloon
+zygarde ex
+dragonair
+nidoqueen
+jangmo o
+metagross gx
+milo
+hoopa gx
+crystal shard
+warp point
+league staff
+mysterious treasure
+mewtwo ex
+ditto ◇
+doduo
+swanna
+bede
+articuno gx
+psychic cube 01
+jirachi
+lusamine
+salazzle gx
+rotom dex
+zygarde
+dragonite
+hakamo o
+nugget
+incineroar gx
+sylveon gx
+unit energy fightingdarknessfairy
+energy search
+eevee
+leon
+desert shaman
+mewtwo ex
+pikachu
+switch
+dodrio
+electrode gx
+tapu fini gx
+ho oh
+seer
+lusamine
+bunnelby
+dragonite gx
+big charm
+cobalion gx
+kommo o gx
+kommo o
+oleana
+fast ball
+ultra ball
+full heal
+m mewtwo ex
+memory capsule
+mimikyu
+stantler
+lickitung
+mars
+mr. mime gx
+super energy removal 2
+ho oh break
+necrozma gx
+lickilicky
+latias
+machamp gx
+psychic energy
+poké ball
+pokémon fan club
+m mewtwo ex
+banette gx
+time shard
+moomoo cheese
+latias & latios gx
+crushing hammer
+fletchling
+fisherman
+deoxys
+smeargle
+drampa gx
+moo moo milk
+ultra necrozma
+wobbuffet break
+scoop up net
+ultra necrozma
+miltank
+latias & latios gx
+aqua patch
+brigette
+mega lopunny & jigglypuff gx
+axew
+scizor gx
+town volunteers
+potion
+lugia
+porygon
+energy retrieval
+skwovet
+friend ball
+volkner
+metal energy
+nessa
+lycanroc gx
+magikarp & wailord gx
+skyla
+eevee & snorlax gx
+enhanced hammer
+lugia gx
+grass energy
+giovanni's scheme
+stakataka gx
+eevee
+beedrill ex
+switch
+traveling salesman
+leafeon gx
+fraxure
+porygon
+hyper potion
+greedent
+energy search
+opal
+marshadow gx
+celebi & venusaur gx
+sonia
+brock's grit
+field blower
+fire energy
+ho oh
+rayquaza gx
+m beedrill ex
+eevee
+mewtwo ex
+darkness energy
+lure ball
+pheromosa gx
+undersea ruins
+alolan muk gx
+pikachu & zekrom gx
+porygon2
+rocky helmet
+haxorus
+energy switch
+rookidee
+tool scrapper
+max potion
+dana
+water energy
+kecleon
+apricorn maker
+mewtwo ex
+igglybuff
+beedrill spirit link
+metal energy
+glaceon gx
+eevee & snorlax gx
+miracle sphere α
+corvisquire
+evolution incense
+telescopic sight
+darkrai gx
+training court
+druddigon
+xurkitree gx
+lightning energy
+corviknight
+kecleon
+black kyurem
+erika's hospitality
+gardevoir gx
+bill's maintenance
+fighting energy
+wyndon stadium
+porygon z
+aipom
+turffield stadium
+power plant
+rare candy
+great ball
+miracle sphere β
+noibat
+detective pikachu
+evelyn
+capture energy
+pikipek
+braixen
+snorlax
+noivern gx
+psychic energy
+double colorless energy
+fire energy
+copycat
+dawn wings necrozma gx
+water cube 01
+ambipom
+flareon gx
+miracle sphere γ
+noivern
+big parasol
+aromatic grass energy
+hop
+ingo & emmet
+horror psychic energy
+pikipek
+bodybuilding dumbbells
+greninja
+fighting energy
+grass energy
+vaporeon gx
+glameow
+naganadel gx
+teddiursa
+grass energy
+coating metal energy
+celesteela gx
+hyper potion
+mirage stadium
+billowing smoke
+lisia
+weakness guard
+jasmine
+darkness energy
+jolteon gx
+speed lightning energy
+ursaring
+weezing
+choice band
+trumbeak
+lickitung
+purugly
+dusk mane necrozma gx
+lightning energy
+steven's resolve
+lucky egg
+bird keeper
+darkness energy
+lightning energy
+stone fighting energy
+mystery plate α
+morgan
+metal energy
+eevee gx
+twin energy
+zangoose
+dialga gx
+volcanion
+happiny
+lickilicky
+toucannon
+escape rope
+fighting energy
+mystery plate β
+tate & liza
+metal energy
+lum berry
+cape of toughness
+wash water energy
+psychic energy
+nanu
+eevee gx
+chatot
+rainbow energy
+nita
+lillipup
+adventure bag
+palkia gx
+kangaskhan
+water energy
+rillaboom v
+multi switch
+fairy energy
+marnie
+familiar bell
+mystery plate γ
+orbeetle v
+magearna
+tv reporter
+eevee gx
+sabrina's suggestion
+eldegoss v
+herdier
+boost energy
+underground expedition
+m gengar ex
+mystery plate δ
+tauros
+crushing hammer
+celesteela gx
+metal saucer
+glimwood tangle
+aether foundation employee
+zarude v
+rescue stretcher
+celebi & venusaur gx
+stoutland
+meltan
+shiftry gx
+crystal energy
+garchomp ex
+mystery zone
+escape board
+ninetales v
+beast bringer
+hoothoot
+super scoop up
+kabu
+choice helmet
+talonflame v
+ordinary rod
+magikarp & wailord gx
+melmetal gx
+rufflet
+blaziken gx
+warp energy
+m garchomp ex
+missing clover
+oracle
+cinderace v
+galarian darmanitan v
+counter gain
+noctowl
+chip chip ice axe
+old pc
+fire energy
+pal pad
+pikachu & zekrom gx
+volcanion
+braviary
+garchomp spirit link
+articuno gx
+kingdra
+star piece
+milotic v
+peeking red card
+pikachu v
+piers
+slakoth
+custom catcher
+poké kid
+darkness energy
+devolution spray z
+ampharos gx
+stakataka
+helioptile
+inteleon v
+underground expedition
+salamence ex
+electrode gx
+lugia
+unit energy grassfirewater
+pokégear 3.0
+slakoth
+electropower
+ampharos v
+gengar & mimikyu gx
+pokémon breeder's nurturing
+dusk stone
+fairy energy
+nidoking
+pokémon catcher
+unit energy lightningpsychicmetal
+m salamence ex
+heliolisk
+dust island
+hoopa gx
+rare fossil
+vigoroth
+mr. mime gx
+alakazam v
+underground lake
+boltund v
+electropower
+melmetal
+toxtricity v
+stufful
+persian
+pokémon center lady
+electromagnetic radar
+salamence spirit link
+faba
+rose
+banette gx
+slaking
+coalossal v
+incineroar gx
+bounce energy
+lunala gx
+cobalion gx
+dragapult v
+pikachu
+bidoof
+bewear
+solgaleo gx
+energy spinner
+volcanion ex
+fairy charm grass
+scizor gx
+galarian sirfetch'd v
+rose tower
+potion
+cyclone energy
+latias & latios gx
+sandaconda v
+eevee
+retro energy
+type: null
+fairy charm ability
+stakataka gx
+pikachu ex
+bibarel
+professor's research (professor magnolia)
+spikemuth
+drapion v
+fairy charm psychic
+eevee & snorlax gx
+typhlosion
+falinks v
+celebi
+silvally gx
+fairy charm lightning
+rayquaza gx
+magearna ex
+steelix v
+quick ball
+munchlax
+struggle gloves
+fairy charm fighting
+dangerous drill
+flareon
+malamar v
+charizard
+beastite
+rayquaza gx
+champions festival
+aegislash v
+fire crystal
+pidove
+rare candy
+electrocharger
+fairy charm dragon
+turbo patch
+alolan marowak gx
+copperajah v
+crobat
+bellelba & brycen man
+judge whistle
+acro bike
+togekiss v
+tranquill
+giovanni's exile
+rotom bike
+karen
+heat factory ◇
+yell horn
+kangaskhan gx
+dubwool v
+metal goggles
+blastoise gx
+green's exploration
+golem
+chaotic swell
+unfezant
+heat fire energy
+kahili
+sitrus berry
+allister
+hustle belt
+karen
+boss's orders
+milo
+pokémon communication
+ho oh
+detective pikachu
+absol
+life forest ◇
+life herb
+janine
+clay
+audino
+bea
+switch
+hiding darkness energy
+oleana
+kabutops
+mewtwo & mew gx
+cynthia & caitlin
+pokénav
+lost blender
+team yell grunt
+koga's trap
+tornadus
+beauty
+powerful colorless energy
+snorlax
+sonia
+lucario & melmetal gx
+dragonium z: dragon claw
+rainbow brush
+fletchling
+vitality band
+lusamine ◇
+lt. surge's strategy
+butterfree v
+leon
+arcanine break
+garchomp & giratina gx
+rillaboom vmax
+erika
+rainbow energy
+yungoos
+martial arts dojo
+aurora energy
+nessa
+mina
+crobat break
+houndoom v
+detective pikachu
+great catcher
+cinderace vmax
+gumshoos
+dhelmise v
+mandibuzz break
+centiskorch v
+opal
+metal core barrier
+mixed herbs
+charizard gx
+guzma & hala
+inteleon vmax
+oranguru
+torkoal v
+mewtwo ex
+vikavolt v
+moomoo milk
+pokémon center lady
+molayne
+mewtwo gx
+island challenge amulet
+toxtricity vmax
+type: null
+giratina
+greninja gx
+lapras v
+pokégear 3.0
+morty
+orbeetle vmax
+rhyperior v
+lana's fishing rod
+dragapult vmax
+silvally
+volcanion
+bulbasaur
+lillie's full force
+morpeko v
+net ball
+galarian darmanitan vmax
+malamar vmax
+copperajah vmax
+magearna
+komala
+psyduck
+lillie's poké doll
+pikachu vmax
+crobat v
+net ball
+wobbuffet v
+boss's orders
+mallow & lana
+snubbull
+scizor v
+professor elm's lecture
+indeedee v
+celebi
+coalossal vmax
+blaine's quiz show
+milo
+power plant
+reshiram & charizard gx
+misty & lorelei
+professor elm's lecture
+shaymin
+galarian stunfisk v
+aegislash vmax
+blizzard town
+stonjourner v
+oleana
+red's challenge
+amoonguss
+n's resolve
+blue's tactics
+togekiss vmax
+victini
+sableye v
+salamence v
+sightseer
+sonia
+samson oak
+tapu fini
+professor oak's setup
+manaphy
+bug catcher
+kabu
+allister
+sightseer
+zacian v
+frosmoth
+necrozma
+red & blue
+stealthy hood
+keldeo
+channeler
+zamazenta v
+bea
+piers
+spell tag
+galarian perrserker
+roller skater
+terrakion
+surprise box
+mew
+beauty
+cherish ball
+pokémon breeder's nurturing
+thunder mountain ◇
+snorlax v
+rosa
+big charm
+pikachu
+ultra forest kartenvoy
+meloetta
+cherish ball
+roxie
+scoop up net
+sudowoodo
+leon
+rose
+wait and see hammer
+cramorant v
+welder
+darkrai
+coach trainer
+vikavolt
+butterfree vmax
+nessa
+tool scrapper
+tag call
+bede
+whitney
+jirachi
+dark city
+stakataka
+unidentified fossil
+twin energy
+centiskorch vmax
+opal
+genesect
+ear ringing bell
+triple acceleration energy
+moltres & zapdos & articuno gx
+will
+marnie
+memory energy
+eternatus vmax
+galarian obstagoon
+pheromosa & buzzwole gx
+shuckle gx
+charizard gx
+draw energy
+flyinium z: air slash
+arceus
+scizor vmax
+professor's research (professor magnolia)
+sceptile gx
+oranguru
+venusaur & snivy gx
+gyarados gx
+pheromosa & buzzwole gx
+team yell grunt
+giant bomb
+m camerupt ex
+salamence vmax
+raichu gx
+cape of toughness
+vileplume gx
+virizion gx
+pokémon breeder's nurturing
+giant hearth
+lapras vmax
+venomoth gx
+m camerupt ex
+mewtwo
+hero's medal
+charizard & braixen gx
+magcargo gx
+great potion
+morpeko vmax
+rose
+reshiram & charizard gx
+camerupt spirit link
+mew
+memory capsule
+volcarona gx
+grimsley
+blacephalon gx
+rillaboom
+stonjourner vmax
+dedenne gx
+m sharpedo ex
+porygon z gx
+telescopic sight
+blastoise & piplup gx
+hapu
+snorlax vmax
+m sharpedo ex
+coalossal
+suicune gx
+trevenant & dusknoir gx
+blastoise & piplup gx
+karate belt
+sharpedo spirit link
+muk & alolan muk gx
+big parasol
+zeraora gx
+bede
+buzzwole
+solgaleo & lunala gx
+misty's favor
+pikachu
+marnie
+turbo patch
+muk & alolan muk gx
+sigilyph gx
+entei
+oricorio gx
+normalium z: tackle
+gym badge
+tyranitar gx
+professor's research (professor magnolia)
+phione
+capture energy
+marshadow & machamp gx
+flygon gx
+poké maniac
+gym badge
+blacephalon
+team yell grunt
+genesect gx
+marshadow & machamp gx
+alolan persian gx
+pokémon research lab
+mismagius
+gym badge
+zacian v
+alolan ninetales gx
+greninja & zoroark gx
+terrakion
+reset stamp
+gym badge
+arceus & dialga & palkia gx
+mimikyu gx
+zamazenta v
+celebi
+arceus & dialga & palkia gx
+reset stamp
+gym badge
+lugia gx
+air balloon
+greninja & zoroark gx
+victini
+reshiram & zekrom gx
+gym badge
+faba
+metal saucer
+slumbering forest
+honchkrow gx
+charizard
+naganadel & guzzlord gx
+gym badge
+stadium nav
+ordinary rod
+judge
+lucario & melmetal gx
+pikachu
+naganadel & guzzlord gx
+tag switch
+gym badge
+kahili
+quick ball
+gardevoir & sylveon gx
+armored mewtwo
+mega lopunny & jigglypuff gx
+unidentified fossil
+lucario spirit link
+mina
+gardevoir & sylveon gx
+venusaur & snivy gx
+mega lopunny & jigglypuff gx
+u turn board
+morty
+charizard & braixen gx
+whimsicott gx
+silvally gx
+recycle energy
+professor elm's lecture
+champions festival
+persian gx
+cynthia & caitlin
+weakness guard energy
+whitney
+pikachu gx
+celesteela gx
+guzma & hala
+rowlet & alolan exeggutor gx
+shuckle gx
+eevee gx
+green's exploration
+lillie's full force
+pikachu
+rowlet & alolan exeggutor gx
+sceptile gx
+janine
+mallow & lana
+eevee
+heatran gx
+koga's trap
+virizion gx
+n's resolve
+alolan sandslash gx
+slowpoke & psyduck gx
+molayne
+magcargo gx
+professor oak's setup
+leafeon
+slowpoke & psyduck gx
+red's challenge
+blacephalon gx
+red & blue
+glaceon
+keldeo gx
+roller skater
+suicune gx
+welder
+carracosta gx
+raichu & alolan raichu gx
+rosa
+pheromosa & buzzwole gx
+zeraora gx
+espeon & deoxys gx
+raichu & alolan raichu gx
+torkoal
+sigilyph gx
+venomoth gx
+umbreon & darkrai gx
+reshiram & charizard gx
+weavile
+eevee gx
+mewtwo & mew gx
+tyranitar gx
+piplup
+regigigas
+latios gx
+blastoise gx
+genesect gx
+wishiwashi
+aipom
+aerodactyl gx
+dedenne gx
+alolan ninetales gx
+pikachu
+mega sableye & tyranitar gx
+mimikyu gx
+muk & alolan muk gx
+magnemite
+mega sableye & tyranitar gx
+lugia gx
+marshadow & machamp gx
+koffing
+mawile gx
+adventure bag
+greninja & zoroark gx
+gallade
+garchomp & giratina gx
+choice helmet
+honchkrow gx
+mimikyu
+dragonite gx
+excadrill
+lucario & melmetal gx
+counter gain
+naganadel gx
+steelix
+custom catcher
+gardevoir & sylveon gx
+blue's tactics
+stoutland
+electropower
+whimsicott gx
+venusaur & snivy gx
+channeler
+persian gx
+lost blender
+vileplume gx
+coach trainer
+net ball
+celesteela gx
+charizard & braixen gx
+grimsley
+spell tag
+beast bringer
+volcarona gx
+misty's favor
+wait and see hammer
+electromagnetic radar
+blastoise & piplup gx
+poké maniac
+fire crystal
+solgaleo & lunala gx
+rowlet & alolan exeggutor gx
+metal core barrier
+oricorio gx
+heatran gx
+pokégear 3.0
+flygon gx
+slowpoke & psyduck gx
+triple acceleration energy
+alolan persian gx
+keldeo gx
+arceus & dialga & palkia gx
+raichu & alolan raichu gx
+reshiram & zekrom gx
+mewtwo & mew gx
+naganadel & guzzlord gx
+latios gx
+mega lopunny & jigglypuff gx
+aerodactyl gx
+silvally gx
+mega sableye & tyranitar gx
+giant hearth
+mawile gx
+great catcher
+garchomp & giratina gx
+island challenge amulet
+lana's fishing rod
+dragonite gx
+lillie's poké doll
+naganadel gx
+martial arts dojo
+cherish ball
+power plant
+giant bomb
+tag call
+karate belt
+draw energy
+reset stamp
+tag switch
+u turn board
+viridian forest
+recycle energy
+weakness guard energy
+rowlet
+dartrix
+decidueye
+yanma
+grookey
+yanmega
+celebi
+thwackey
+cacnea
+rillaboom
+blipbug
+tropius
+dottler
+rowlet
+dartrix
+orbeetle
+decidueye
+gossifleur
+dhelmise v
+dhelmise vmax
+eldegoss
+grookey
+thwackey
+rillaboom
+gossifleur
+eldegoss
+applin
+flapple
+appletun
+zarude
+scorbunny
+raboot
+reshiram
+cinderace
+sizzlipede
+cinderace v
+centiskorch
+cinderace vmax
+galarian mr. mime
+horsea
+kyogre
+galarian mr. rime
+buizel
+floatzel
+suicune
+galarian darumaka
+manaphy
+volcanion
+galarian darmanitan
+sobble
+chewtle
+drizzile
+drednaw
+cramorant
+inteleon
+chewtle
+snom
+drednaw
+frosmoth
+cramorant
+shinx
+luxio
+arrokuda
+barraskewda
+luxray
+rotom
+snom
+morpeko
+morpeko
+frosmoth
+morpeko v
+eiscue
+morpeko vmax
+indeedee v
+dracovish
+trapinch
+arctovish
+koffing
+rotom
+galarian weezing
+yamper
+boltund
+spinarak
+crobat v
+toxel
+crobat vmax
+toxtricity
+yveltal
+pincurchin
+morpeko
+nickit
+thievul
+dracozolt
+cufant
+arctozolt
+ditto v
+galarian ponyta
+ditto vmax
+eevee
+galarian rapidash
+greedent v
+galarian corsola
+cramorant v
+cramorant vmax
+galarian cursola
+indeedee
+dedenne
+sinistea
+ball guy
+polteageist
+boss's orders
+gym trainer
+hatenna
+hattrem
+professor's research
+rusted shield
+hatterene
+rusted sword
+milcery
+team yell towel
+alcremie
+alcremie v
+indeedee
+dreepy
+drakloak
+ball guy
+dragapult
+bird keeper
+cara liss
+galarian farfetch'd
+galarian sirfetch'd
+gym trainer
+galarian yamask
+piers
+poké kid
+galarian runerigus
+rose
+rolycoly
+skyla
+carkol
+alcremie vmax
+coalossal
+silicobra
+sandaconda
+clobbopus
+grapploct
+falinks
+stonjourner
+koffing
+galarian weezing
+galarian zigzagoon
+galarian linoone
+galarian obstagoon
+nickit
+thievul
+impidimp
+morgrem
+grimmsnarl
+galarian meowth
+galarian perrserker
+galarian stunfisk
+corviknight
+cufant
+copperajah
+duraludon
+minccino
+cinccino
+ducklett
+swanna
+bunnelby
+oranguru
+skwovet
+greedent
+rookidee
+corvisquire
+wooloo
+dubwool
+rillaboom v
+rillaboom vmax
+charizard vmax
+centiskorch v
+centiskorch vmax
+lapras v
+lapras vmax
+toxtricity v
+toxtricity vmax
+indeedee v
+falinks v
+grimmsnarl v
+grimmsnarl vmax
+ditto v
+ditto vmax
+dubwool v
+eternatus v
+eternatus vmax
+pikachu v
+zacian v
+zamazenta v
+orbeetle v
+galarian mr. rime
+dedenne
+polteageist
+bunnelby
+alakazam v
+eldegoss v
+boltund v
+cramorant v
+eevee vmax
+dragapult v
+dragapult vmax
+crobat v
+crobat vmax
+venusaur v
+blastoise v
+dedenne gx
+bellsprout
+weepinbell
+victreebel
+cacnea
+cacturne
+kricketune v
+cherubi
+cherrim
+carnivine
+durant
+scatterbug
+spewpa
+vivillon
+fomantis
+lurantis
+tapu bulu
+blipbug
+flapple v
+flapple vmax
+entei
+victini v
+victini vmax
+tepig
+pignite
+emboar
+heatmor
+salandit
+salazzle
+sizzlipede
+centiskorch
+horsea
+seadra
+kingdra
+galarian mr. mime
+galarian mr. rime
+remoraid
+octillery
+corphish
+crawdaunt
+empoleon v
+frillish
+jellicent
+bruxish
+electabuzz
+electivire
+shinx
+luxio
+luxray
+pachirisu
+tapu koko v
+tapu koko vmax
+yamper
+boltund
+galarian slowpoke
+spoink
+grumpig
+baltoy
+claydol
+chimecho
+espurr
+meowstic
+mimikyu v
+necrozma v
+dottler
+orbeetle
+mankey
+primeape
+onix
+cubone
+marowak
+gligar
+gliscor
+timburr
+gurdurr
+conkeldurr
+mienfoo
+mienshao
+rolycoly
+carkol
+coalossal
+silicobra
+sandaconda
+falinks
+stonjourner
+single strike urshifu v
+single strike urshifu vmax
+rapid strike urshifu v
+rapid strike urshifu vmax
+zubat
+golbat
+crobat
+galarian slowbro
+murkrow
+honchkrow
+houndour
+houndoom
+tyranitar v
+morpeko
+steelix
+mawile
+bronzor
+bronzong
+pawniard
+bisharp
+honedge
+doublade
+aegislash
+aegislash
+corviknight v
+corviknight vmax
+spearow
+fearow
+lickitung
+lickilicky
+glameow
+purugly
+stoutland v
+bouffalant
+drampa
+indeedee
+bruno
+camping gear
+cheryl
+energy recycler
+escape rope
+exp. share
+fan of waves
+korrina's focus
+level ball
+phoebe
+rapid strike scroll of swirls
+rapid strike style mustard
+single strike scroll of scorn
+single strike style mustard
+sordward & shielbert
+tool jammer
+tower of darkness
+tower of waters
+urn of vitality
+rapid strike energy
+single strike energy
+kricketune v
+flapple v
+victini v
+empoleon v
+empoleon v
+tapu koko v
+mimikyu v
+necrozma v
+single strike urshifu v
+single strike urshifu v
+rapid strike urshifu v
+rapid strike urshifu v
+tyranitar v
+tyranitar v
+corviknight v
+stoutland v
+bruno
+cheryl
+korrina's focus
+phoebe
+rapid strike style mustard
+single strike style mustard
+single strike urshifu vmax
+rapid strike urshifu vmax
+cherrim
+octillery
+houndoom
+bronzong
+charmander
+arrokuda
+jolteon
+eevee
+venusaur vmax
+blastoise vmax
+single strike urshifu v
+rapid strike urshifu v
+flapple vmax
+victini vmax
+tapu koko vmax
+single strike urshifu vmax
+rapid strike urshifu vmax
+corviknight vmax
+bruno
+cheryl
+korrina's focus
+phoebe
+rapid strike style mustard
+single strike style mustard
+octillery
+houndoom
+exp. share
+level ball
+rapid strike energy
+single strike energy
+weedle
+kakuna
+beedrill
+ledyba
+ledian
+heracross
+celebi v
+celebi vmax
+snover
+abomasnow
+deerling
+sawsbuck
+bounsweet
+steenee
+tsareena
+grookey
+thwackey
+rillaboom
+zarude
+blaziken v
+blaziken vmax
+castform sunny form
+larvesta
+volcarona
+volcanion v
+scorbunny
+raboot
+cinderace
+lapras
+sneasel
+weavile
+delibird
+castform rainy form
+castform snowy form
+snorunt
+froslass
+spheal
+sealeo
+walrein
+tapu fini
+sobble
+drizzile
+inteleon
+rapid strike urshifu
+ice rider calyrex v
+ice rider calyrex vmax
+mareep
+flaaffy
+ampharos
+blitzle
+zebstrika
+thundurus
+zeraora v
+galarian slowpoke
+gastly
+haunter
+gengar
+galarian articuno v
+ralts
+kirlia
+gardevoir
+shuppet
+banette
+cresselia
+golett
+golurk
+swirlix
+slurpuff
+inkay
+malamar
+hatenna
+hattrem
+hatterene
+shadow rider calyrex v
+shadow rider calyrex vmax
+diglett
+dugtrio
+galarian farfetch'd
+galarian sirfetch'd
+galarian zapdos v
+gallade
+galarian yamask
+galarian runerigus
+crabrawler
+crabominable
+rockruff
+lycanroc
+passimian
+sandaconda v
+sandaconda vmax
+clobbopus
+grapploct
+kubfu
+koffing
+weezing
+galarian weezing
+galarian moltres v
+galarian slowking
+galarian slowking v
+galarian slowking vmax
+qwilfish
+seviper
+spiritomb
+liepard v
+venipede
+whirlipede
+scolipede
+single strike urshifu
+aron
+lairon
+aggron
+metagross v
+metagross vmax
+cobalion
+tauros
+porygon
+porygon2
+porygon z
+blissey v
+zangoose
+castform
+kecleon
+shaymin
+tornadus v
+tornadus vmax
+furfrou
+skwovet
+greedent
+agatha
+avery
+brawly
+caitlin
+crushing gloves
+doctor
+dyna tree hill
+echoing horn
+expedition uniform
+fire resistant gloves
+flannery
+fog crystal
+galarian chestplate
+honey
+justified gloves
+karen's conviction
+klara
+melony
+old cemetery
+path to the peak
+peonia
+peony
+rapid strike scroll of the skies
+rugged helmet
+siebold
+single strike scroll of piercing
+weeding gloves
+welcoming lantern
+impact energy
+lucky energy
+spiral energy
+celebi v
+blaziken v
+volcanion v
+ice rider calyrex v
+ice rider calyrex v
+zeraora v
+zeraora v
+galarian rapidash v
+galarian rapidash v
+galarian articuno v
+galarian articuno v
+shadow rider calyrex v
+shadow rider calyrex v
+galarian zapdos v
+galarian zapdos v
+sandaconda v
+galarian moltres v
+galarian moltres v
+galarian slowking v
+galarian slowking v
+liepard v
+metagross v
+blissey v
+blissey v
+tornadus v
+tornadus v
+agatha
+avery
+brawly
+caitlin
+doctor
+flannery
+honey
+karen's conviction
+klara
+melony
+peonia
+peony
+siebold
+victini v
+gardevoir v
+empoleon v
+tyranitar v
+galarian rapidash v
+cinderace
+inteleon
+cresselia
+passimian
+morpeko
+phanpy
+eevee
+snorlax
+professor's research
+celebi vmax
+blaziken vmax
+blaziken vmax
+ice rider calyrex vmax
+ice rider calyrex vmax
+shadow rider calyrex vmax
+shadow rider calyrex vmax
+sandaconda vmax
+galarian slowking vmax
+metagross vmax
+tornadus vmax
+agatha
+avery
+brawly
+caitlin
+doctor
+flannery
+karen's conviction
+klara
+melony
+peonia
+peony
+siebold
+electrode
+bronzong
+snorlax
+echoing horn
+fan of waves
+fog crystal
+rugged helmet
+urn of vitality
+welcoming lantern
+water energy
+psychic energy
+fighting energy
+hoppip
+jumpluff
+tropius
+pinsir
+skiploom
+seedot
+leafeon vmax
+lilligant
+petilil
+crustle
+trevenant v
+dwebble
+leafeon v
+trevenant vmax
+sharpedo
+glaceon vmax
+wishiwashi
+bergmite
+carvanha
+cryogonal
+dracozolt vmax
+dracozolt v
+vaporeon vmax
+gyarados v
+eiscue
+ludicolo
+tympole
+golduck
+suicune v
+pikachu
+glaceon v
+psyduck
+eldegoss
+tentacool
+tentacruel
+lotad
+raichu
+lanturn
+entei
+luvdisc
+litleo
+pyroar
+gyarados vmax
+chinchou
+mareep
+applin
+feebas
+milotic
+avalugg
+flareon vmax
+jolteon vmax
+ampharos
+emolga
+gossifleur
+volcarona v
+flaaffy
+victini
+lombre
+arctovish v
+galarian articuno
+hypno
+regieleki
+drowzee
+wobbuffet
+espeon v
+espeon vmax
+swoobat
+sableye
+woobat
+golurk v
+florges
+flabébé
+floette
+sylveon v
+sylveon vmax
+pumpkaboo
+gourgeist
+cutiefly
+hitmonchan
+ribombee
+marshadow
+medicham v
+hippopotas
+hippowdon
+galarian zapdos
+gigalith
+roggenrola
+boldore
+seismitoad
+palpitoad
+lycanroc v
+umbreon v
+lycanroc vmax
+nuzleaf
+umbreon vmax
+galarian moltres
+scrafty
+scraggy
+shiftry
+zoroark
+zorua
+garbodor v
+garbodor vmax
+altaria
+nickit
+thievul
+shelgon
+bagon
+salamence
+rayquaza vmax
+dialga
+deino
+rayquaza v
+kyurem
+hydreigon
+noivern v
+zweilous
+drampa
+zygarde
+flapple
+appletun
+duraludon v
+regidrago
+duraludon vmax
+smeargle
+teddiursa
+slakoth
+vigoroth
+eevee
+ursaring
+slaking
+swablu
+fletchling
+herdier
+lillipup
+rufflet
+braviary
+fletchinder
+stoutland
+aroma lady
+talonflame
+crystal cave
+digging gloves
+boost shake
+copycat
+elemental badge
+full face guard
+dream ball
+gordie
+lucky ice pop
+moon & sun badge
+rubber gloves
+rescue carrier
+raihan
+ribbon badge
+rapid strike scroll of the flying dragon
+shopping center
+single strike scroll of the fanged dragon
+spirit mask
+snow leaf badge
+zinnia's resolve
+switching cups
+stormy mountains
+leafeon v
+toy catcher
+treasure energy
+leafeon v
+trevenant v
+flareon v
+suicune v
+volcarona v
+gyarados v
+vaporeon v
+dracozolt v
+jolteon v
+glaceon v
+glaceon v
+arctovish v
+espeon v
+golurk v
+espeon v
+sylveon v
+golurk v
+medicham v
+medicham v
+sylveon v
+lycanroc v
+umbreon v
+umbreon v
+dragonite v
+garbodor v
+rayquaza v
+dragonite v
+noivern v
+rayquaza v
+noivern v
+aroma lady
+duraludon v
+copycat
+duraludon v
+gordie
+leafeon vmax
+raihan
+zinnia's resolve
+leafeon vmax
+trevenant vmax
+glaceon vmax
+gyarados vmax
+sylveon vmax
+dracozolt vmax
+sylveon vmax
+glaceon vmax
+lycanroc vmax
+umbreon vmax
+rayquaza vmax
+garbodor vmax
+umbreon vmax
+rayquaza vmax
+duraludon vmax
+duraludon vmax
+aroma lady
+copycat
+zinnia's resolve
+raihan
+gordie
+cresselia
+froslass
+inteleon
+crystal cave
+boost shake
+lightning energy
+turffield stadium
+toy catcher
+full face guard
+stormy mountains
+darkness energy
+metal energy
+umbreon
+marnie
+eevee
+shadow rider calyrex v
+galarian articuno
+marnie
+flaaffy
+eiscue
+galarian moltres
+ice rider calyrex v
+galarian zapdos
+crobat v
+galarian slowpoke
+ho oh
+palkia
+reshiram
+flying pikachu vmax
+kyogre
+xerneas
+surfing pikachu v
+cosmoem
+surfing pikachu vmax
+lunala
+zekrom
+groudon
+professor's research (professor oak)
+solgaleo
+cosmog
+pikachu
+flying pikachu v
+mew
+dialga
+lugia
+professor's research (professor oak)
+zacian v
+zamazenta v
+yveltal
+mew
+charizard
+blastoise
+venusaur
+here comes team rocket!
+claydol
+rocket's zapdos
+imposter professor oak
+dark gyarados
+shining magikarp
+_____'s pikachu
+cleffa
+rocket's admin.
+umbreon ★
+mew ex
+gardevoir ex δ
+team magma's groudon
+luxray gl lv.x
+garchomp c lv.x
+reshiram
+zekrom
+mewtwo ex
+xerneas ex
+tapu lele gx
+donphan
+m rayquaza ex
+chespin
+pikachu
+inkay
+furfrou
+weedle
+froakie
+honedge
+snubbull
+bunnelby
+fletchling
+swirlix
+fennekin
+treecko
+lotad
+pikachu
+zigzagoon
+torchic
+meditite
+marill
+mudkip
+rhyhorn
+staryu
+electrike
+skitty
+crabrawler
+grubbin
+popplio
+alolan meowth
+rowlet
+litten
+pikachu
+cosmog
+cutiefly
+alolan diglett
+pikipek
+yungoos
+horsea
+psyduck
+growlithe
+pikachu
+slowpoke
+machop
+cubone
+chansey
+magnemite
+dratini
+eevee
+porygon
+turtwig
+treecko
+tepig
+totodile
+oshawott
+chikorita
+chespin
+torchic
+scorbunny
+piplup
+popplio
+bulbasaur
+grookey
+charmander
+chimchar
+fennekin
+litten
+squirtle
+snivy
+rowlet
+cyndaquil
+mudkip
+froakie
+sobble
+pikachu
+electabuzz
+hitmonchan
+rocket's scizor
+professor elm
+dark ivysaur
+rocket's sneasel
+dark venusaur
+rocket's mewtwo
+rocket's hitmonchan
+reshiram & charizard gx
+mismagius
+sabrina & brycen
+caterpie
+metapod
+butterfree
+shroomish
+breloom v
+breloom
+pansage
+simisage
+sewaddle
+swadloon
+leavanny
+maractus
+shelmet
+trevenant
+phantump
+accelgor
+virizion
+grubbin
+araquanid
+dewpider
+rillaboom v
+tsareena v
+gossifleur
+eldegoss
+rillaboom vmax
+appletun v
+zarude
+ninetales
+vulpix
+ninetales
+vulpix
+slugma
+growlithe
+arcanine
+magcargo
+oricorio
+pansear
+simisear
+chandelure v
+chandelure vmax
+cinderace v
+victini
+heatmor
+centiskorch
+cinderace v
+centiskorch
+cinderace vmax
+sizzlipede
+sizzlipede
+shellder
+starmie
+cloyster
+totodile
+lapras
+staryu
+croconaw
+feraligatr
+mantine
+marill
+azumarill
+qwilfish
+mudkip
+marshtomp
+clamperl
+huntail
+swampert
+simipour
+basculin
+galarian darumaka
+panpour
+gorebyss
+clauncher
+greninja v
+galarian darmanitan
+clawitzer
+inteleon v
+crabominable v
+pyukumuku
+inteleon vmax
+arrokuda
+chewtle
+drednaw
+barraskewda
+snom
+frosmoth
+pikachu v
+plusle
+voltorb
+electrode
+minun
+shinx
+luxio
+luxray
+tynamo
+rotom
+eelektrik
+helioptile
+vikavolt
+heliolisk
+eelektross
+charjabug
+zeraora
+boltund v
+boltund vmax
+toxel
+toxel
+toxtricity
+toxtricity
+mew v
+wigglytuff
+jigglypuff
+jynx
+morpeko
+mew vmax
+snubbull
+granbull
+galarian corsola
+galarian cursola
+mawile
+munna
+musharna
+deoxys
+sigilyph
+meloetta
+sandygast
+palossand
+indeedee
+dreepy
+dragapult
+drakloak
+mankey
+sandshrew
+sandslash
+geodude
+primeape
+golem
+steelix
+graveler
+onix
+makuhita
+gligar
+gliscor
+baltoy
+hariyama
+drilbur
+lucario v
+landorus
+pancham
+stufful
+claydol
+bewear
+grapploct
+falinks
+clobbopus
+falinks
+gengar v
+gengar vmax
+galarian linoone
+tyranitar v
+galarian zigzagoon
+galarian obstagoon
+carvanha
+sharpedo
+absol
+croagunk
+toxicroak
+darkrai
+trubbish
+zorua
+garbodor
+zoroark
+vullaby
+mandibuzz
+pangoro
+grimmsnarl
+morgrem
+galarian meowth
+yveltal
+morpeko
+impidimp
+durant
+skarmory
+galarian perrserker
+excadrill
+genesect v
+togedemaru
+klefki
+melmetal
+meltan
+corviknight
+cufant
+copperajah
+latias
+latios
+goomy
+goodra
+sliggoo
+persian
+turtonator
+meowth
+dodrio v
+chansey
+blissey
+kangaskhan
+eevee
+dunsparce
+stantler
+skitty
+smeargle
+snorlax
+delcatty
+buneary
+lopunny
+diggersby
+hawlucha
+bunnelby
+corvisquire
+greedent vmax
+greedent v
+rookidee
+wooloo
+dubwool
+wooloo
+adventurer's discovery
+battle vip pass
+bug catcher
+cram o matic
+cook
+cross switcher
+chili & cilan & cress
+crossceiver
+dancer
+farewell bell
+judge
+elesa's sparkle
+power tablet
+quick ball
+schoolboy
+shauna
+schoolgirl
+skaters' park
+sidney
+spongy gloves
+fusion strike energy
+tsareena v
+celebi v
+mew v
+chandelure v
+crabominable v
+boltund v
+hoopa v
+sandaconda v
+mew v
+genesect v
+greedent v
+greedent v
+dancer
+schoolgirl
+elesa's sparkle
+sidney
+training court
+chili & cilan & cress
+elesa's sparkle
+sidney
+boltund vmax
+gengar vmax
+chili & cilan & cress
+schoolgirl
+power tablet
+fire energy
+genesect v
+chandelure vmax
+schoolboy
+shauna
+inteleon vmax
+mew vmax
+mew vmax
+espeon vmax
+greedent vmax
+schoolboy
+shauna
+grass energy
+dancer
+flaaffy
+pikachu on the ball
+eevee on the ball
+grookey on the ball
+scorbunny on the ball
+sobble on the ball
+pikachu vmax
+dragapult
+lance's charizard v
+dark sylveon v
+zacian lv.x
+mimikyu δ
+light toxtricity
+hydreigon c
+pikachu v union
+pikachu v union
+pikachu v union
+pikachu v union
+pikachu v
+greninja ★
+pikachu v
+poké ball
+rayquaza v
+noivern v
+flareon v
+vaporeon v
+jolteon v
+dragonite v
+greninja v union
+greninja v union
+greninja v union
+greninja v union
+mewtwo v union
+mewtwo v union
+mewtwo v union
+mewtwo v union
+zacian v union
+zacian v union
+zacian v union
+zacian v union
+professor burnet
+oricorio
+pyukumuku
+deoxys
+latias
+tepig
+blitzle
+espeon
+eevee
+hoopa v
+flareon v
+flareon vmax
+vaporeon v
+vaporeon vmax
+jolteon v
+jolteon vmax
+pikachu & zekrom gx
+bagon
+combusken
+delcatty
+latias
+numel
+skitty
+torchic
+potion
+energy search
+fire energy
+electrike
+latios
+linoone
+magnemite
+magneton
+pikachu
+zigzagoon
+potion
+energy search
+lightning energy
+beldum
+electrike
+grumpig
+meowth
+metang
+plusle
+spoink
+energy search
+potion
+professor cozmo's discovery
+lightning energy
+psychic energy
+arcanine
+charmander
+charmeleon
+growlithe
+mareep
+minun
+vulpix
+celio's network
+energy search
+potion
+fire energy
+lightning energy
+pokégear 3.0
+pokégear 3.0
+welder
+jirachi gx
+hex maniac
+leafeon v
+leafeon vstar
+glaceon v
+glaceon vstar
+exeggcute
+exeggutor
+shroomish
+breloom
+tropius
+turtwig
+grotle
+torterra
+burmy
+wormadam
+mothim
+cherubi
+shaymin v
+shaymin vstar
+karrablast
+zarude v
+charizard v
+charizard vstar
+magmar
+magmortar
+moltres
+entei v
+torkoal
+chimchar
+monferno
+infernape
+simisear v
+kingler v
+kingler vmax
+staryu
+lapras
+corphish
+crawdaunt
+snorunt
+piplup
+prinplup
+empoleon
+buizel
+floatzel
+lumineon v
+manaphy
+cubchoo
+beartic
+eiscue
+raichu v
+electabuzz
+electivire
+raikou v
+shinx
+luxio
+luxray
+pachirisu
+clefairy
+clefable
+starmie
+mewtwo
+granbull v
+baltoy
+claydol
+duskull
+dusclops
+dusknoir
+chimecho
+whimsicott v
+whimsicott vstar
+sigilyph
+dedenne
+mimikyu v
+mimikyu vmax
+milcery
+alcremie
+hitmontop
+nosepass
+trapinch
+vibrava
+flygon
+wormadam
+riolu
+lucario
+throh
+sawk
+golett
+golurk
+grimer
+muk
+sneasel
+weavile
+honchkrow v
+spiritomb
+purrloin
+liepard
+impidimp
+morgrem
+grimmsnarl
+morpeko v
+aggron v
+aggron vmax
+wormadam
+probopass
+heatran
+escavalier
+klink
+klang
+klinklang
+zamazenta v
+flygon v
+gible
+gabite
+garchomp
+axew
+fraxure
+haxorus
+druddigon
+dracovish v
+farfetch'd
+castform
+starly
+staravia
+staraptor
+bidoof
+bibarel
+arceus v
+arceus vstar
+minccino
+cinccino
+tornadus
+hawlucha
+drampa v
+acerola's premonition
+barry
+blunder policy
+boss's orders
+café master
+cheren's care
+choice belt
+cleansing gloves
+collapsed stadium
+cynthia's ambition
+fresh water set
+friends in galar
+gloria
+hunting gloves
+kindler
+magma basin
+marnie's pride
+pot helmet
+professor's research
+roseanne's backup
+team yell's cheer
+ultra ball
+double turbo energy
+shaymin v
+charizard v
+charizard v
+lumineon v
+lumineon v
+pikachu v
+raichu v
+granbull v
+whimsicott v
+honchkrow v
+honchkrow v
+zamazenta v
+flygon v
+arceus v
+arceus v
+barry
+cheren's care
+cynthia's ambition
+kindler
+marnie's pride
+roseanne's backup
+shaymin vstar
+charizard vstar
+whimsicott vstar
+arceus vstar
+cheren's care
+cynthia's ambition
+kindler
+roseanne's backup
+galarian articuno v
+galarian zapdos v
+galarian moltres v
+arceus vstar
+magma basin
+ultra ball
+flareon
+vaporeon
+octillery
+jolteon
+zekrom
+dusknoir
+dedenne
+alcremie
+ariados
+houndoom
+eevee
+oranguru
+boltund v
+sylveon v
+sylveon vmax
+mimikyu v
+mimikyu vmax
+single strike urshifu v
+single strike urshifu vmax
+rapid strike urshifu v
+rapid strike urshifu vmax
+umbreon v
+umbreon vmax
+acerola's premonition
+café master
+gloria
+rapid strike style mustard
+single strike style mustard
+single strike urshifu vmax
+rapid strike urshifu vmax
+moltres
+lucario
+liepard
+bibarel
+flapple
+eevee
+leafeon
+glaceon
+galarian obstagoon
+pikachu v
+lycanroc v
+corviknight v
+espeon v
+sylveon v
+umbreon v
+arceus v
+lucario v
+lucario vstar
+morpeko v union
+morpeko v union
+morpeko v union
+morpeko v union
+boltund v
+rowlet
+cyndaquil
+oshawott
+beedrill v
+hisuian voltorb
+hisuian electrode
+scyther
+scyther
+yanma
+yanmega
+heracross
+kricketot
+kricketune
+combee
+vespiquen
+leafeon
+shaymin
+petilil
+hisuian lilligant
+hisuian lilligant v
+hisuian lilligant vstar
+rowlet
+dartrix
+ponyta
+rapidash
+cyndaquil
+quilava
+heatran v
+heatran vmax
+radiant heatran
+psyduck
+golduck
+starmie v
+swinub
+piloswine
+mamoswine
+mantine
+barboach
+whiscash
+regice
+glaceon
+origin forme palkia v
+origin forme palkia vstar
+oshawott
+dewott
+hisuian basculin
+hisuian basculegion
+keldeo
+radiant greninja
+bergmite
+hisuian avalugg
+galarian mr. rime v
+luxray v
+regieleki
+hisuian typhlosion
+hisuian typhlosion v
+hisuian typhlosion vstar
+togepi
+togetic
+togekiss
+misdreavus
+mismagius
+ralts
+kirlia
+gallade
+drifloon
+drifblim
+uxie
+mesprit
+azelf
+diancie
+wyrdeer
+hisuian growlithe
+hisuian arcanine
+machamp v
+machamp vmax
+sudowoodo
+regirock
+cranidos
+rampardos
+lucario v
+hippopotas
+hippowdon
+radiant hawlucha
+hisuian decidueye
+hisuian decidueye v
+hisuian decidueye vstar
+kleavor
+kleavor
+kleavor v
+hisuian qwilfish
+hisuian qwilfish
+hisuian overqwil
+hisuian overqwil
+hisuian sneasel
+hisuian sneasler
+hisuian sneasler v
+poochyena
+mightyena
+absol
+darkrai v
+darkrai vstar
+hisuian samurott
+hisuian samurott v
+hisuian samurott vstar
+nickit
+thievul
+magnemite
+magneton
+magnezone
+registeel
+shieldon
+bastiodon
+bronzor
+bronzong
+origin forme dialga v
+origin forme dialga vstar
+pawniard
+bisharp
+garchomp v
+regidrago
+eevee
+hoothoot
+noctowl
+teddiursa
+ursaring
+ursaluna
+stantler
+miltank
+glameow
+purugly
+chatot
+regigigas
+rufflet
+hisuian braviary
+oranguru v
+wyrdeer v
+adaman
+canceling cologne
+choy
+cyllene
+dark patch
+energy loto
+feather ball
+gapejaw bog
+gardenia's vigor
+grant
+gutsy pickaxe
+hisuian heavy ball
+irida
+jubilife village
+kamado
+roxanne
+spicy seasoned curry
+supereffective glasses
+sweet honey
+switch cart
+temple of sinnoh
+trekking shoes
+unidentified fossil
+wait and see turbo
+zisu
+beedrill v
+beedrill v
+hisuian lilligant v
+hisuian lilligant v
+virizion v
+heatran v
+starmie v
+origin forme palkia v
+luxray v
+hisuian typhlosion v
+jirachi v
+machamp v
+machamp v
+hisuian decidueye v
+hisuian sneasler v
+hisuian sneasler v
+hisuian samurott v
+origin forme dialga v
+garchomp v
+oranguru v
+wyrdeer v
+adaman
+choy
+cyllene
+gardenia's vigor
+grant
+irida
+kamado
+roxanne
+zisu
+hisuian lilligant vstar
+heatran vmax
+origin forme palkia vstar
+hisuian typhlosion vstar
+machamp vmax
+hisuian decidueye vstar
+kleavor vstar
+hisuian samurott vstar
+origin forme dialga vstar
+adaman
+choy
+cyllene
+gardenia's vigor
+grant
+irida
+kamado
+roxanne
+zisu
+origin forme palkia vstar
+hisuian samurott vstar
+origin forme dialga vstar
+choice belt
+jubilife village
+path to the peak
+temple of sinnoh
+trekking shoes
+double turbo energy
+abomasnow
+flapple
+kingdra
+frosmoth
+gardevoir
+wyrdeer
+falinks
+kleavor
+mightyena
+galarian obstagoon
+bronzong
+hoothoot
+starmie v
+ice rider calyrex v
+ice rider calyrex vmax
+galarian articuno v
+shadow rider calyrex v
+shadow rider calyrex vmax
+galarian zapdos v
+galarian moltres v
+zacian v
+zamazenta v
+garchomp v
+allister
+bea
+melony
+milo
+piers
+ice rider calyrex vmax
+shadow rider calyrex vmax
+bulbasaur
+ivysaur
+venusaur
+radiant venusaur
+alolan exeggutor v
+spinarak
+ariados
+charmander
+charmeleon
+charizard
+radiant charizard
+moltres
+numel
+camerupt
+squirtle
+wartortle
+blastoise
+radiant blastoise
+slowpoke
+slowbro
+magikarp
+gyarados
+lapras
+articuno
+wimpod
+golisopod
+pikachu
+pikachu
+zapdos
+mewtwo v
+mewtwo vstar
+natu
+xatu
+lunatone
+sylveon
+onix
+larvitar
+pupitar
+solrock
+conkeldurr v
+alolan rattata
+alolan raticate
+tyranitar
+steelix
+meltan
+melmetal
+melmetal v
+melmetal vmax
+dragonite v
+dragonite vstar
+chansey
+blissey
+ditto
+eevee
+snorlax
+aipom
+ambipom
+slaking v
+bidoof
+bibarel
+pidove
+tranquill
+unfezant
+blanche
+candela
+egg incubator
+lure module
+pokéstop
+rare candy
+spark
+alolan exeggutor v
+mewtwo v
+conkeldurr v
+conkeldurr v
+melmetal v
+dragonite v
+slaking v
+professor's research
+mewtwo vstar
+melmetal vmax
+dragonite vstar
+blanche
+candela
+professor's research
+spark
+mewtwo vstar
+egg incubator
+lure module
+special delivery bidoof
+hisuian basculegion
+wyrdeer
+hisuian samurott
+magnezone
+toxel
+oricorio
+sylveon
+eevee
+kleavor v
+kleavor vstar
+professor's research
+mewtwo v
+melmetal v
+alolan exeggutor v
+spark
+blanche
+candela
+mewtwo v
+radiant eevee
+bulbasaur
+charmander
+squirtle
+pikachu
+hisuian typhlosion v
+hisuian decidueye v
+hisuian samurott v
+lumineon v
+oddish
+gloom
+vileplume
+paras
+parasect
+wurmple
+silcoon
+beautifly
+cascoon
+dustox
+seedot
+nuzleaf
+shiftry
+roselia
+roserade
+phantump
+trevenant
+blipbug
+dottler
+orbeetle
+slugma
+magcargo
+torkoal
+litwick
+lampent
+chandelure
+delphox v
+litleo
+pyroar
+poliwag
+poliwhirl
+politoed
+seel
+dewgong
+horsea
+seadra
+kingdra
+luvdisc
+shellos
+finneon
+lumineon
+snover
+abomasnow
+hisuian basculin
+hisuian basculegion
+ducklett
+swanna
+kyurem v
+kyurem vmax
+cramorant
+glastrier
+pikachu
+raichu
+electrike
+manectric
+magnezone v
+magnezone vstar
+rotom v
+tynamo
+eelektrik
+eelektross
+clefairy
+clefable
+gastly
+haunter
+gengar
+mr. mime
+jynx
+radiant gardevoir
+sableye
+mawile
+shuppet
+banette
+cresselia
+hisuian zorua
+hisuian zoroark
+inkay
+malamar
+comfey
+mimikyu
+spectrier
+enamorus v
+hisuian growlithe
+hisuian arcanine
+poliwrath
+machop
+machoke
+machamp
+rhyhorn
+rhydon
+rhyperior
+aerodactyl v
+aerodactyl vstar
+sudowoodo
+gligar
+gliscor
+makuhita
+hariyama
+meditite
+medicham
+relicanth
+gastrodon
+mienfoo
+mienshao
+landorus
+binacle
+barbaracle
+carbink
+rockruff
+falinks
+stonjourner
+spinarak
+ariados
+murkrow
+honchkrow
+seviper
+spiritomb
+drapion v
+drapion vstar
+darkrai
+inkay
+hoopa
+radiant hisuian sneasler
+radiant steelix
+bronzor
+bronzong
+galarian stunfisk
+magearna
+galarian perrserker v
+giratina v
+giratina vstar
+goomy
+hisuian sliggoo
+hisuian goodra
+hisuian goodra v
+hisuian goodra vstar
+pidgeot v
+lickitung
+lickilicky
+porygon
+porygon2
+porygon z
+snorlax
+aipom
+ambipom
+hisuian zoroark v
+hisuian zoroark vstar
+bouffalant
+komala
+skwovet
+greedent
+arc phone
+arezu
+box of disaster
+colress's experiment
+damage pump
+fantina
+iscan
+lady
+lake acuity
+lost city
+lost vacuum
+mirage gate
+miss fortune sisters
+panic mask
+riley
+thorton
+tool box
+volo
+windup arm
+gift energy
+hisuian electrode v
+delphox v
+kyurem v
+magnezone v
+rotom v
+rotom v
+enamorus v
+aerodactyl v
+aerodactyl v
+gallade v
+drapion v
+galarian perrserker v
+galarian perrserker v
+giratina v
+giratina v
+hisuian goodra v
+pidgeot v
+arezu
+colress's experiment
+fantina
+iscan
+lady
+miss fortune sisters
+thorton
+volo
+kyurem vmax
+magnezone vstar
+aerodactyl vstar
+drapion vstar
+giratina vstar
+hisuian goodra vstar
+hisuian zoroark vstar
+arezu
+colress's experiment
+fantina
+iscan
+lady
+miss fortune sisters
+thorton
+volo
+giratina vstar
+hisuian zoroark vstar
+box of disaster
+collapsed stadium
+dark patch
+lost vacuum
+parasect
+roserade
+charizard
+chandelure
+pikachu
+gengar
+banette
+hisuian arcanine
+spiritomb
+snorlax
+castform
+orbeetle v
+orbeetle vmax
+centiskorch v
+centiskorch vmax
+pikachu v
+pikachu vmax
+enamorus v
+gallade v
+crobat v
+eternatus v
+eternatus vmax
+adventurer's discovery
+boss's orders
+cook
+kabu
+nessa
+opal
+pikachu vmax
+mew vmax
+venonat
+venomoth
+spinarak
+ariados
+sunkern
+sunflora
+serperior v
+serperior vstar
+petilil
+hisuian lilligant
+foongus
+amoonguss
+durant
+virizion
+chesnaught v
+radiant tsareena
+vulpix
+ninetales
+growlithe
+arcanine
+ponyta
+rapidash
+victini
+reshiram v
+fennekin
+braixen
+delphox
+fletchinder
+talonflame
+litten
+torracat
+incineroar
+alolan vulpix v
+alolan vulpix vstar
+omastar v
+articuno
+wailmer
+wailord
+feebas
+milotic
+snorunt
+glalie
+froslass
+relicanth
+phione
+keldeo
+dewpider
+araquanid
+pikachu
+raichu
+chinchou
+lanturn
+rotom
+emolga
+stunfisk
+zeraora
+regieleki v
+regieleki vmax
+radiant alakazam
+drowzee
+hypno
+jynx
+misdreavus
+mismagius
+unown v
+unown vstar
+ralts
+kirlia
+gardevoir
+mawile v
+mawile vstar
+meditite
+medicham
+chimecho
+sigilyph
+solosis
+duosion
+reuniclus
+elgyem
+beheeyem
+espurr
+meowstic
+swirlix
+slurpuff
+dedenne
+indeedee
+dreepy
+drakloak
+dragapult
+hisuian arcanine v
+phanpy
+donphan
+baltoy
+claydol
+anorith
+armaldo
+terrakion
+hawlucha
+sandygast
+palossand
+stonjourner
+ursaluna v
+zubat
+golbat
+crobat
+murkrow
+honchkrow
+skuntank v
+croagunk
+toxicroak
+sandile
+krokorok
+krookodile
+mareanie
+toxapex
+morpeko
+beldum
+metang
+metagross
+radiant jirachi
+ferroseed
+ferrothorn
+klink
+klang
+klinklang
+cobalion
+togedemaru
+magearna v
+dratini
+dragonair
+dragonite
+noibat
+noivern
+zygarde
+regidrago v
+regidrago vstar
+smeargle
+lugia v
+lugia vstar
+ho oh v
+spinda
+swablu
+altaria
+buneary
+lopunny
+archen
+archeops
+rufflet
+hisuian braviary
+fletchling
+brandon
+candice
+capturing aroma
+earthen seal stone
+emergency jelly
+forest seal stone
+furisode girl
+gym trainer
+lance
+leafy camo poncho
+primordial altar
+professor laventon
+quad stone
+serena
+unidentified fossil
+wallace
+worker
+regenerative energy
+v guard energy
+serperior v
+chesnaught v
+reshiram v
+alolan vulpix v
+omastar v
+regieleki v
+unown v
+unown v
+mawile v
+hisuian arcanine v
+skuntank v
+skuntank v
+magearna v
+regidrago v
+regidrago v
+lugia v
+lugia v
+ho oh v
+brandon
+candice
+furisode girl
+gym trainer
+lance
+serena
+wallace
+worker
+serperior vstar
+alolan vulpix vstar
+regieleki vmax
+unown vstar
+mawile vstar
+regidrago vstar
+lugia vstar
+brandon
+candice
+furisode girl
+lance
+serena
+wallace
+worker
+serperior vstar
+lugia vstar
+energy switch
+gapejaw bog
+leafy camo poncho
+v guard energy
+braixen
+milotic
+flaaffy
+jynx
+gardevoir
+malamar
+rockruff
+passimian
+druddigon
+smeargle
+altaria
+kricketune v
+serperior v
+blaziken v
+blaziken vmax
+zeraora v
+mawile v
+corviknight v
+corviknight vmax
+rayquaza vmax
+duraludon vmax
+blissey v
+friends in galar
+gordie
+judge
+professor burnet
+raihan
+sordward & shielbert
+rayquaza vmax
+duraludon vmax
+pikachu
+dragonite v
+dragonite vstar
+finneon
+gengar
+comfey
+machamp
+scorbunny
+croagunk
+weavile
+regigigas
+infernape v
+origin forme palkia v
+origin forme palkia vstar
+origin forme dialga v
+origin forme dialga vstar
+rotom v
+gallade v
+giratina v
+charizard v
+charizard vmax
+charizard vstar
+zeraora v
+zeraora vmax
+zeraora vstar
+deoxys v
+deoxys vmax
+deoxys vstar
+sunflora
+rapidash
+kirlia
+archeops
+hisuian basculin
+cranidos
+manaphy
+togetic
+hisuian electrode v
+virizion v
+champions festival
+hisuian zoroark v
+hisuian zoroark vstar
+ledyba
+rowlet
+gossifleur
+growlithe
+victini
+lapras
+pikachu
+chinchou
+flaaffy
+tynamo
+cutiefly
+bewear
+pangoro
+drampa
+smeargle
+oddish
+gloom
+bellossom
+tangela
+tangrowth
+scyther
+sunkern
+yanma
+yanmega
+kricketot
+cherubi
+carnivine
+leafeon v
+leafeon vstar
+grubbin
+zarude
+calyrex
+charizard v
+charizard vstar
+radiant charizard
+entei
+simisear v
+simisear vstar
+larvesta
+volcarona
+volcanion
+salandit
+salazzle
+seel
+galarian mr. mime
+wailmer
+wailord
+corphish
+snorunt
+luvdisc
+kyogre
+kyogre v
+glaceon v
+shinx
+shinx
+luxio
+luxio
+luxray
+luxray
+rotom v
+rotom vstar
+emolga
+eelektrik
+helioptile
+heliolisk
+radiant charjabug
+zeraora
+zeraora v
+zeraora vmax
+zeraora vstar
+pincurchin
+exeggcute
+exeggutor
+mewtwo
+mew v
+girafarig
+lunatone
+dusclops
+tapu lele
+hatterene v
+hatterene vmax
+enamorus
+graveler
+solrock
+baltoy
+riolu
+pancham
+rockruff
+lycanroc
+koffing
+absol
+purrloin
+liepard
+krokorok
+pangoro
+skrelp
+dragalge
+hoopa
+galarian meowth
+galarian perrserker
+scizor
+aron
+lairon
+aggron
+metang
+pawniard
+pawniard
+bisharp
+zacian
+zacian v
+zacian vstar
+zamazenta
+zamazenta v
+zamazenta vstar
+rayquaza v
+rayquaza vmax
+rayquaza vmax
+duraludon v
+duraludon vmax
+radiant eternatus
+tauros
+ditto
+eevee v
+snorlax
+starly
+bidoof
+chatot
+regigigas v
+regigigas vstar
+shaymin
+stoutland v
+yungoos
+gumshoos
+oranguru
+greedent v
+wooloo
+dubwool
+bea
+bede
+crushing hammer
+digging duo
+energy retrieval
+energy search
+energy switch
+friends in hisui
+friends in sinnoh
+great ball
+hop
+leon
+lost vacuum
+nessa
+poké ball
+pokémon catcher
+potion
+raihan
+rare candy
+rescue carrier
+sky seal stone
+switch
+trekking shoes
+ultra ball
+elesa's sparkle
+friends in hisui
+friends in sinnoh
+professor's research
+volo
+grass energy
+fire energy
+water energy
+lightning energy
+psychic energy
+fighting energy
+darkness energy
+metal energy
+pikachu
+hisuian voltorb
+kricketune
+magmortar
+oricorio
+lapras
+manaphy
+keldeo
+electivire
+toxtricity
+mew
+lunatone
+deoxys
+diancie
+comfey
+solrock
+absol
+thievul
+magnezone
+altaria
+latias
+hisuian goodra
+ditto
+dunsparce
+miltank
+bibarel
+riolu
+swablu
+duskull
+bidoof
+pikachu
+turtwig
+paras
+poochyena
+mareep
+leafeon vstar
+entei v
+simisear vstar
+suicune v
+lumineon v
+glaceon vstar
+raikou v
+zeraora vmax
+zeraora vstar
+mewtwo vstar
+deoxys vmax
+deoxys vstar
+hatterene vmax
+zacian v
+drapion v
+darkrai vstar
+hisuian samurott v
+hisuian samurott vstar
+hoopa v
+zamazenta v
+regigigas vstar
+hisuian zoroark vstar
+adaman
+cheren's care
+colress's experiment
+cynthia's ambition
+gardenia's vigor
+grant
+irida
+melony
+raihan
+roxanne
+origin forme palkia vstar
+origin forme dialga vstar
+giratina vstar
+arceus vstar
+rillaboom
+cinderace
+inteleon
+regieleki v
+regidrago v
+lucario vstar
+scatterbug
+pineco
+cacturne
+gogoat
+sprigatito
+meowscarada
+tarountula
+tarountula
+smoliv
+smoliv
+spidops ex
+arboliva
+toedscool
+heracross
+breloom
+tropius
+vivillon
+skiddo
+floragato
+toedscruel
+shroomish
+cacnea
+spewpa
+tarountula
+dolliv
+toedscool
+gyarados ex
+scovillain
+bruxish
+wiglett
+crocalor
+wugtrio
+skeledirge
+cetoddle
+charcadet
+buizel
+cetitan
+clauncher
+clawitzer
+quaxwell
+quaquaval
+wiglett
+capsakid
+growlithe
+capsakid
+arcanine ex
+torkoal
+fuecoco
+charcadet
+slowbro
+floatzel
+alomomola
+growlithe
+houndour
+houndoom
+armarouge
+slowpoke
+magikarp
+quaxly
+cetoddle
+dondozo
+magnemite
+magneton
+tatsugiri
+rotom
+mareep
+pawmot
+pawmo
+miraidon
+wattrel
+miraidon ex
+wattrel
+hypno
+kilowattrel
+gardevoir ex
+dedenne
+drowzee
+klefki
+ralts
+fidough
+kirlia
+fidough
+shuppet
+flittle
+drifloon
+drifblim
+flabébé
+magnezone ex
+flaaffy
+toxel
+toxtricity
+pawmi
+florges
+flittle
+pachirisu
+rotom
+pawmi
+banette ex
+floette
+dedenne
+dachsbun
+flittle
+greavard
+greavard
+espathra
+houndstone
+mankey
+primeape
+annihilape
+medicham
+meditite
+riolu
+riolu
+lucario
+sandile
+krookodile
+hawlucha
+krokorok
+silicobra
+sandaconda
+stonjourner
+great tusk ex
+klawf
+koraidon
+koraidon ex
+grimer
+muk
+seviper
+pawniard
+spiritomb
+croagunk
+toxicroak ex
+bisharp
+kingambit
+maschiff
+maschiff
+forretress
+mabosstiff
+bombirdier
+varoom
+revavroom
+varoom
+iron treads ex
+chansey
+blissey
+zangoose
+starly
+zangoose
+skwovet
+staravia
+staraptor
+indeedee
+greedent
+lechonk
+oinkologne ex
+oinkologne
+lechonk
+lechonk
+tandemaus
+tandemaus
+squawkabilly
+maushold
+cyclizar
+cyclizar
+flamigo
+arven
+beach court
+energy switch
+defiance band
+energy retrieval
+energy search
+exp. share
+crushing hammer
+electric generator
+judge
+mesagoza
+jacq
+katy
+miriam
+nemona
+nest ball
+penny
+pal pad
+picnic basket
+poké ball
+pokémon catcher
+potion
+pokégear 3.0
+professor's research (professor sada)
+rare candy
+professor's research (professor turo)
+rock chestplate
+rocky helmet
+switch
+team star grunt
+ultra ball
+youngster
+dolliv
+vitality band
+tarountula
+toedscool
+armarouge
+scovillain
+wiglett
+slowpoke
+clauncher
+pawmot
+pachirisu
+drowzee
+dondozo
+greavard
+riolu
+ralts
+kirlia
+fidough
+klawf
+mabosstiff
+sandile
+bombirdier
+kingambit
+starly
+skwovet
+arcanine ex
+magnezone ex
+gyarados ex
+spidops ex
+gardevoir ex
+miraidon ex
+banette ex
+koraidon ex
+great tusk ex
+iron treads ex
+toxicroak ex
+oinkologne ex
+arven
+katy
+jacq
+miriam
+professor's research (professor turo)
+professor's research (professor sada)
+penny
+team star grunt
+spidops ex
+miraidon ex
+gardevoir ex
+great tusk ex
+iron treads ex
+koraidon ex
+arven
+jacq
+penny
+miriam
+miraidon ex
+nest ball
+rare candy
+koraidon ex
+basic fighting energy
+basic lightning energy
+sprigatito
+fuecoco
+pawmot
+espathra
+hawlucha
+miraidon
+revavroom
+spidops
+arcanine
+quaxly
+quaquaval
+mimikyu ex
+koraidon
+dondozo
+pikachu v
+pikachu vmax
+hoppip
+skiploom
+pineco
+jumpluff
+tropius
+forretress ex
+heracross
+sprigatito
+sprigatito
+floragato
+spidops
+meowscarada ex
+tarountula
+tarountula
+combee
+vespiquen
+snover
+abomasnow
+nymble
+lokix
+bramblin
+nymble
+brambleghast
+rellor
+rellor
+bramblin
+wo chien ex
+fuecoco
+crocalor
+charcadet
+gyarados
+luvdisc
+quaxly
+quaxwell
+fletchinder
+litleo
+pyroar
+paldean tauros
+skeledirge ex
+chi yu ex
+magikarp
+marill
+azumarill
+delibird
+quaquaval ex
+talonflame
+oricorio
+fuecoco
+charcadet
+paldean tauros
+eiscue
+quaxly
+cetoddle
+veluza
+frigibax
+magnemite
+arctibax
+pikachu ex
+cetoddle
+cetitan
+frigibax
+baxcalibur
+chien pao ex
+pikachu
+raichu
+shinx
+tadbulb
+wattrel
+spiritomb
+gothitelle
+tinkatuff
+tinkatuff
+mankey
+pincurchin
+pawmi
+pawmo
+pawmot
+tadbulb
+jigglypuff
+wigglytuff
+misdreavus
+gothorita
+dedenne ex
+mimikyu
+primeape
+sudowoodo
+larvitar
+makuhita
+voltorb
+electrode
+bellibolt ex
+kilowattrel
+slowking ex
+gothita
+oranguru
+sandygast
+tinkatink
+tinkatink
+tinkaton
+paldean tauros
+pupitar
+shinx
+luxio
+luxray
+pincurchin
+wattrel
+slowpoke
+mismagius
+palossand
+ceruledge
+rabsca
+tinkatink
+lycanroc ex
+rockruff
+hariyama
+croagunk
+toxicroak
+passimian
+falinks
+nacli
+nacli
+garganacl
+paldean wooper
+murkrow
+honchkrow
+weavile
+sableye
+zweilous
+hydreigon
+shroodle
+copperajah ex
+glimmet
+glimmora
+seviper
+maschiff
+grafaiai
+bombirdier
+corviknight
+cufant
+girafarig
+naclstack
+ting lu ex
+paldean wooper
+sneasel
+noibat
+glimmet
+paldean clodsire ex
+tyranitar
+deino
+maschiff
+mabosstiff
+shroodle
+orthworm
+noivern ex
+dudunsparce
+wingull
+slakoth
+vigoroth
+slaking
+fletchling
+dunsparce
+pelipper
+corvisquire
+farigiraf
+rookidee
+tandemaus
+tandemaus
+maushold
+artazon
+boss's orders (ghetsis)
+bravery charm
+choice belt
+delivery drone
+flamigo
+squawkabilly ex
+calamitous snowy mountain
+calamitous wasteland
+clavell
+tropius
+bramblin
+giacomo
+grusha
+jet energy
+heracross
+fletchinder
+pyroar
+fuecoco
+crocalor
+magikarp
+falkner
+fighting au lait
+great ball
+practice studio
+saguaro
+super rod
+luminous energy
+therapeutic energy
+dendra
+iono
+superior energy retrieval
+reversal energy
+sprigatito
+floragato
+frigibax
+raichu
+arctibax
+tinkatink
+tinkatuff
+nacli
+tyranitar
+orthworm
+rookidee
+eiscue
+quaxwell
+mismagius
+sandygast
+sudowoodo
+grafaiai
+maushold
+marill
+quaxly
+baxcalibur
+gothorita
+rabsca
+paldean tauros
+paldean wooper
+forretress ex
+dedenne ex
+copperajah ex
+squawkabilly ex
+iono
+saguaro
+wo chien ex
+wo chien ex
+quaquaval ex
+bellibolt ex
+slowking ex
+ting lu ex
+noivern ex
+clavell
+grusha
+meowscarada ex
+quaquaval ex
+chien pao ex
+ting lu ex
+boss's orders (ghetsis)
+dendra
+farigiraf
+chi yu ex
+annihilape ex
+paldean clodsire ex
+boss's orders (ghetsis)
+dendra
+falkner
+giacomo
+squawkabilly ex
+flamigo
+dudunsparce
+meowscarada ex
+skeledirge ex
+chien pao ex
+tinkaton ex
+lycanroc ex
+skeledirge ex
+chi yu ex
+tinkaton ex
+grusha
+iono
+giacomo
+saguaro
+quaquaval ex
+skeledirge ex
+meowscarada ex
+ting lu ex
+super rod
+chien pao ex
+superior energy retrieval
+basic water energy
+basic grass energy
+flaaffy
+lucario ex
+ampharos ex
+cyclizar ex
+special delivery charizard
+galarian articuno
+klara
+greninja
+morpeko v union
+arceus v
+morpeko v union
+zacian v
+zamazenta v
+arceus vstar
+boss's orders
+galarian zapdos
+galarian moltres
+morpeko v union
+morpeko v union
+bulbasaur
+arcanine
+basic water energy
+basic grass energy
+basic darkness energy
+basic lightning energy
+basic metal energy
+basic fire energy
+basic psychic energy
+basic fighting energy
+pelipper
+baxcalibur
+tinkaton
+murkrow
+smoliv
+tinkatink
+pikachu
+koraidon ex
+growlithe
+varoom
+miraidon ex
+surskit
+gloom
+oddish
+phantump
+steenee
+charmeleon
+camerupt
+victini ex
+darmanitan
+scyther
+foongus
+capsakid
+scovillain
+numel
+darumaka
+combee
+bellossom
+shuckle
+masquerain
+amoonguss
+trevenant
+decidueye ex
+bounsweet
+tsareena
+smoliv
+dolliv
+toedscruel ex
+vulpix
+rowlet
+dartrix
+arboliva
+capsakid
+charmander
+ninetales
+entei
+litwick
+eiscue ex
+lapras
+buizel
+beartic
+wiglett
+finizen
+palafin
+magneton
+magnezone
+thundurus
+toxel
+tadbulb
+clefable ex
+espeon
+granbull
+baltoy
+claydol
+vespiquen ex
+sinistea
+diglett
+barboach
+whiscash
+crabrawler
+crabominable
+rockruff
+lycanroc
+glimmet
+paldean wooper
+paldean clodsire
+heatmor
+floatzel
+tympole
+cubchoo
+cryogonal
+magnemite
+tyranitar ex
+tynamo
+eelektrik
+eelektross
+tadbulb
+cleffa
+clefairy
+togepi
+togekiss
+snubbull
+lunatone
+greavard
+larvitar
+pupitar
+toedscruel
+koraidon ex
+lampent
+volcarona
+armarouge
+sharpedo
+seismitoad
+toxtricity
+bellibolt
+mawile
+spoink
+greavard
+nosepass
+bonsly
+drilbur
+stunfisk
+klawf ex
+paldean clodsire
+chandelure
+larvesta
+charcadet
+carvanha
+palpitoad
+froakie
+frogadier
+wugtrio
+finizen
+pawmot ex
+tadbulb
+bellibolt
+miraidon ex
+togetic
+grumpig
+solrock
+polteageist
+houndstone
+houndstone ex
+dugtrio
+diggersby
+toedscool
+glimmet
+glimmora ex
+charizard ex
+paldean wooper
+houndour
+houndour
+houndoom
+scizor
+darkrai
+skarmory
+salandit
+togedemaru
+bronzor
+meltan
+bronzong
+melmetal ex
+bisharp
+dragonair
+kingambit
+pidgey
+inkay
+umbreon
+malamar
+salazzle
+mawile
+excadrill
+dratini
+dragonite ex
+drampa
+houndoom ex
+absol ex
+probopass
+pawniard
+varoom
+varoom
+revavroom ex
+altaria
+pidgeot ex
+kangaskhan
+pidgeotto
+eevee
+linoone
+zigzagoon
+swablu
+lillipup
+bouffalant
+yungoos
+greedent ex
+lechonk
+geeta
+letter of encouragement
+bunnelby
+gumshoos
+lechonk
+ortega
+stoutland
+audino
+oinkologne
+flamigo
+arven
+brassius
+herdier
+skwovet
+lechonk
+oinkologne
+patrol cap
+poppy
+vengeful punch
+pokémon league headquarters
+palafin
+team star grunt
+vespiquen ex
+ninetales
+charizard ex
+cleffa
+pidgeot ex
+larvitar
+ryme
+houndour
+eiscue ex
+varoom
+pidgeot ex
+pidgey
+geeta
+glimmora ex
+charizard ex
+basic fire energy
+artazon
+pidgeotto
+ryme
+lechonk
+town store
+tyranitar ex
+gloom
+absol ex
+bellibolt
+poppy
+scizor
+charizard ex
+eiscue ex
+revavroom ex
+geeta
+ortega
+revavroom ex
+poppy
+chien pao ex
+tinkaton ex
+annihilape ex
+palafin
+cleffa
+togekiss
+mawile
+pawmi
+paldean wooper
+houndstone
+eevee
+charmander
+paradise resort
+ivysaur
+bulbasaur
+venusaur ex
+squirtle
+rattata
+wartortle
+ekans
+blastoise ex
+arbok ex
+butterfree
+pikachu
+pidgey
+nidoran ♀
+spearow
+nidorino
+nidorina
+nidoking
+nidoran ♂
+clefairy
+clefable
+gloom
+vileplume
+paras
+dugtrio
+parasect
+diglett
+charmander
+kakuna
+charmeleon
+charizard ex
+caterpie
+metapod
+weedle
+pidgeotto
+pidgeot
+raichu
+sandshrew
+sandslash
+nidoqueen
+jigglypuff
+wigglytuff ex
+zubat
+oddish
+venomoth
+beedrill
+raticate
+fearow
+vulpix
+ninetales ex
+golbat
+venonat
+meowth
+persian
+arcanine
+psyduck
+poliwag
+poliwhirl
+victreebel
+rapidash
+magneton
+dodrio
+gastly
+gengar
+onix
+growlithe
+kadabra
+machop
+bellsprout
+tentacool
+tentacruel
+golem ex
+ponyta
+slowpoke
+farfetch'd
+doduo
+mankey
+abra
+machoke
+machamp
+weepinbell
+graveler
+magnemite
+seel
+grimer
+haunter
+golduck
+primeape
+poliwrath
+alakazam ex
+geodude
+slowbro
+dewgong
+muk
+shellder
+cloyster
+hypno
+cubone
+marowak
+hitmonlee
+hitmonchan
+rhydon
+kangaskhan ex
+seadra
+seaking
+staryu
+magmar
+tauros
+flareon
+omanyte
+omastar
+aerodactyl
+snorlax
+voltorb
+koffing
+rhyhorn
+horsea
+pinsir
+magikarp
+gyarados
+kabuto
+kabutops
+articuno
+drowzee
+kingler
+electrode
+exeggutor
+chansey
+tangela
+goldeen
+mr. mime
+jynx ex
+electabuzz
+jolteon
+porygon
+krabby
+exeggcute
+lickitung
+weezing
+starmie
+scyther
+lapras
+ditto
+eevee
+vaporeon
+dragonair
+dragonite
+bill's transfer
+cycling road
+grabber
+leftovers
+caterpie
+pikachu
+mewtwo
+antique dome fossil
+antique helix fossil
+energy sticker
+erika's invitation
+protective goggles
+rigid band
+charmander
+antique old amber
+daisy's help
+bulbasaur
+charmeleon
+wartortle
+zapdos ex
+moltres
+dratini
+mew ex
+big air balloon
+giovanni's charisma
+ivysaur
+squirtle
+machoke
+golem ex
+mr. mime
+omanyte
+arbok ex
+wigglytuff ex
+alakazam ex
+zapdos ex
+mew ex
+nidoking
+dragonair
+venusaur ex
+ninetales ex
+jynx ex
+psyduck
+poliwhirl
+tangela
+charizard ex
+blastoise ex
+kangaskhan ex
+daisy's help
+erika's invitation
+giovanni's charisma
+bill's transfer
+venusaur ex
+charizard ex
+blastoise ex
+alakazam ex
+switch
+zapdos ex
+erika's invitation
+giovanni's charisma
+mew ex
+basic psychic energy
+meowscarada ex
+skeledirge ex
+bulbasaur
+charmander
+mewtwo
+squirtle
+mew ex
+greninja ex
+pikachu
+quaquaval ex
+alakazam ex
+kangaskhan ex
+zapdos ex
+snorlax
+surskit
+masquerain
+froslass ex
+pansage
+simisage
+dwebble
+crustle
+bounsweet
+steenee
+blipbug
+dottler
+orbeetle
+nymble
+nymble
+toedscool
+toedscool
+toedscruel
+wo chien
+magby
+pansear
+simisear
+volcanion
+fuecoco
+crocalor
+charcadet
+charcadet
+armarouge ex
+iron moth
+chi yu
+horsea
+seadra
+kingdra
+remoraid
+octillery
+feebas
+milotic
+snorunt
+garchomp ex
+mantyke
+palkia
+panpour
+simipour
+vanillite
+vanillish
+vanilluxe
+tsareena ex
+wimpod
+wimpod
+golisopod
+golisopod ex
+wiglett
+wiglett
+wugtrio
+veluza
+dondozo
+iron bundle
+chien pao
+mewtwo ex
+elekid
+plusle
+minun
+blitzle
+zebstrika
+joltik
+galvantula
+zekrom
+oricorio
+tapu koko ex
+toxel
+iron hands ex
+natu
+xatu
+latios
+deoxys
+yamask
+cofagrigus ex
+pumpkaboo
+gourgeist
+flittle
+flittle
+espathra
+tinkatink
+tinkatink
+tinkatuff
+tinkaton
+scream tail
+gimmighoul
+gimmighoul
+iron valiant ex
+onix
+gligar
+gliscor
+groudon
+gible
+gabite
+mienfoo
+mienshao
+hoopa ex
+minior
+toxtricity ex
+nacli
+nacli
+naclstack
+garganacl
+klawf
+flamigo
+slither wing
+sandy shocks ex
+ting lu
+zubat
+golbat
+crobat
+absol
+purrloin
+liepard
+trubbish
+garbodor
+yveltal
+nickit
+thievul
+morpeko
+lokix
+brute bonnet
+roaring moon ex
+steelix
+jirachi
+ferroseed
+ferrothorn
+durant
+honedge
+honedge
+doublade
+doublade
+aegislash
+aegislash ex
+zacian
+skeledirge ex
+orthworm
+gholdengo ex
+altaria ex
+tatsugiri
+porygon
+porygon2
+porygon z
+aipom
+ambipom
+miltank
+whismur
+loudred
+exploud
+spinda
+swablu
+tandemaus
+tandemaus
+maushold ex
+bombirdier ex
+cyclizar
+iron jugulis
+ancient booster energy capsule
+counter catcher
+cursed duster
+defiance vest
+earthen vessel
+future booster energy capsule
+larry
+luxurious cape
+mela
+norman
+parasol lady
+professor sada's vitality
+professor turo's scenario
+rika
+roark
+shauntal
+snorlax doll
+technical machine: blindside
+technical machine: devolution
+technical machine: evolution
+technical machine: turbo energize
+techno radar
+tulip
+medical energy
+crustle
+dottler
+toedscruel
+magby
+iron moth
+snorunt
+mantyke
+vanillish
+wimpod
+veluza
+plusle
+minun
+blitzle
+joltik
+espathra
+gimmighoul
+groudon
+mienshao
+minior
+garganacl
+slither wing
+garbodor
+yveltal
+morpeko
+brute bonnet
+steelix
+ferrothorn
+aegislash
+aipom
+loudred
+swablu
+porygon z
+cyclizar
+iron jugulis
+froslass ex
+armarouge ex
+garchomp ex
+tsareena ex
+golisopod ex
+tapu koko ex
+iron hands ex
+cofagrigus ex
+iron valiant ex
+hoopa ex
+toxtricity ex
+sandy shocks ex
+roaring moon ex
+aegislash ex
+gholdengo ex
+altaria ex
+maushold ex
+bombirdier ex
+larry
+mela
+norman
+parasol lady
+professor sada's vitality
+professor turo's scenario
+rika
+roark
+shauntal
+tulip
+garchomp ex
+golisopod ex
+tapu koko ex
+iron hands ex
+iron valiant ex
+sandy shocks ex
+roaring moon ex
+gholdengo ex
+altaria ex
+mela
+parasol lady
+professor sada's vitality
+professor turo's scenario
+rika
+tulip
+garchomp ex
+iron valiant ex
+roaring moon ex
+beach court
+counter catcher
+luxurious cape
+reversal energy
+pineco
+forretress ex
+magmar
+maractus
+magmortar
+heat rotom
+lapras
+pikachu
+camerupt
+charcadet
+kilowattrel
+exeggcute
+natu
+toedscool
+toedscruel ex
+espathra ex
+charmander
+frigibax
+raichu
+chinchou
+charmeleon
+numel
+armarouge
+lanturn
+exeggutor
+xatu
+gardevoir ex
+chimecho
+houndstone
+annihilape
+scraggy
+woobat
+lechonk
+electric generator
+swoobat
+nest ball
+dedenne
+paldean student
+fidough
+paldean student
+dachsbun
+technical machine: crisis punch
+flittle
+ultra ball
+gimmighoul
+scyther
+barboach
+pineco
+clobbopus
+snover
+grapploct
+abomasnow
+paldean wooper
+varoom
+cyclizar
+oinkologne
+tandemaus
+clive
+nemona
+professor's research
+professor's research
+rare candy
+gloom
+smoliv
+ralts
+mime jr.
+cottonee
+ceruledge
+primeape
+donphan
+great tusk ex
+scrafty
+revavroom
+noibat
+noivern ex
+artazon
+atticus
+oddish
+hoppip
+skiploom
+jumpluff
+dolliv
+arboliva
+kirlia
+whimsicott
+mimikyu
+greavard
+mankey
+phanpy
+charizard ex
+gastly
+haunter
+gengar
+paldean clodsire ex
+maschiff
+mabosstiff
+iron treads ex
+gholdengo
+maushold
+squawkabilly ex
+iono
+moonlit hill
+nemona's backpack
+vileplume
+charmander
+entei
+oricorio
+rellor
+charcadet
+armarouge
+slowpoke
+slowbro
+toedscool
+charmeleon
+paldean tauros
+staryu
+capsakid
+scovillain
+starmie
+wugtrio
+palafin
+frigibax
+electrode
+luxio
+thundurus
+tatsugiri
+arctibax
+baxcalibur
+voltorb
+paldean tauros
+veluza
+dondozo
+pikachu
+pachirisu
+wiglett
+finizen
+raichu
+shinx
+luxray
+pawmi
+pawmot
+wattrel
+toxtricity
+kilowattrel
+toxel
+pawmo
+wigglytuff
+abra
+natu
+xatu
+ralts
+kirlia
+drifloon
+drifblim
+spiritomb
+tinkatink
+annihilape
+nacli
+garganacl
+paldean wooper
+pawniard
+bisharp
+mabosstiff
+shroodle
+grafaiai
+flittle
+tinkaton
+weavile
+scizor
+mime jr.
+mimikyu
+dachsbun
+ceruledge
+houndstone
+primeape
+hawlucha
+naclstack
+murkrow
+sneasel
+sableye
+kadabra
+cleffa
+klefki
+rabsca
+tinkatuff
+mankey
+paldean tauros
+riolu
+lucario
+glimmet
+kingambit
+varoom
+revavroom
+pidgey
+jigglypuff
+doduo
+noibat
+cyclizar
+pidgeotto
+dodrio
+ditto
+snorlax
+wingull
+pelipper
+maushold
+oinkologne
+tandemaus
+toedscruel ex
+palafin
+mew ex
+nemona
+forretress ex
+espathra ex
+pawmi
+clive
+judge
+paldean student
+paldean student
+arven
+miraidon ex
+flamigo
+alakazam ex
+mew ex
+gardevoir ex
+glimmora ex
+paldean clodsire ex
+noivern ex
+wugtrio
+gardevoir ex
+clive
+chien pao ex
+ting lu ex
+skwovet
+greedent
+lechonk
+pidgeot ex
+wigglytuff ex
+squawkabilly ex
+nemona
+charizard ex
+iono
+penny
+wo chien ex
+chi yu ex
+koraidon ex
+chi yu
+pineco
+xatu
+sinistea
+charizard ex
+iron bundle
+aegislash
+cetitan
+greavard
+scream tail
+mimikyu
+roaring moon ex
+arctibax
+iron valiant ex
+iron bundle
+fidough
+maschiff
+pikachu with grey felt hat
+oddish
+scyther
+pineco
+seedot
+nuzleaf
+shiftry
+shroomish
+breloom
+roselia
+roserade
+turtwig
+grotle
+torterra ex
+shaymin
+whimsicott
+cottonee
+deerling
+sawsbuck
+grubbin
+bramblin
+brambleghast
+rabsca
+dhelmise
+rellor
+scovillain ex
+iron leaves ex
+ponyta
+rapidash
+slugma
+magcargo
+victini
+heatmor
+litten
+torracat
+incineroar ex
+turtonator
+sizzlipede
+centiskorch
+gouging fire ex
+totodile
+croconaw
+feraligatr
+carvanha
+sharpedo
+keldeo
+snom
+frosmoth
+wiglett
+finizen
+palafin
+walking wake ex
+pikachu
+raichu
+electabuzz
+electivire
+charjabug
+vikavolt
+zeraora
+yamper
+boltund
+wugtrio ex
+iron hands
+iron thorns
+mr. mime
+marill
+azumarill
+girafarig
+latias
+bronzor
+bronzong
+solosis
+duosion
+reuniclus
+elgyem
+beheeyem
+cutiefly
+ribombee
+scream tail
+flutter mane
+iron valiant
+iron valiant
+iron crown ex
+meditite
+medicham
+relicanth
+drilbur
+excadrill
+golett
+golurk
+rockruff
+lycanroc
+mudbray
+mudsdale
+rolycoly
+carkol
+coalossal
+great tusk
+great tusk
+sandy shocks
+iron boulder ex
+ekans
+arbok
+gastly
+haunter
+gengar ex
+mightyena
+poochyena
+sableye
+farigiraf ex
+roaring moon
+forretress
+scizor ex
+mawile
+metang
+meltan
+beldum
+metagross
+melmetal
+iron treads
+raging bolt ex
+koraidon
+lickitung
+koraidon ex
+miraidon
+miraidon ex
+lickilicky
+hoothoot
+noctowl
+dudunsparce
+dunsparce
+skitty
+delcatty
+chatot
+pidove
+tranquill
+unfezant
+minccino
+drampa
+cinccino
+iron jugulis
+ancient booster energy capsule
+awakening drum
+bianca's devotion
+boxed order
+buddy buddy poffin
+eri
+ciphermaniac's codebreaking
+explorer's guidance
+full metal lab
+future booster energy capsule
+hand trimmer
+heavy baton
+hero's cape
+master ball
+maximum belt
+morty's conviction
+perilous jungle
+prime catcher
+reboot pod
+rescue board
+salvatore
+mist energy
+neo upper energy
+shiftry
+grotle
+deerling
+sawsbuck
+litten
+snom
+charjabug
+bronzor
+reuniclus
+cutiefly
+relicanth
+excadrill
+mudsdale
+arbok
+gastly
+metagross
+meltan
+lickitung
+chatot
+minccino
+cinccino
+drampa
+torterra ex
+iron leaves ex
+incineroar ex
+gouging fire ex
+walking wake ex
+wugtrio ex
+iron crown ex
+iron boulder ex
+scizor ex
+farigiraf ex
+gengar ex
+raging bolt ex
+bianca's devotion
+eri
+explorer's guidance
+salvatore
+ciphermaniac's codebreaking
+morty's conviction
+iron leaves ex
+gouging fire ex
+walking wake ex
+iron boulder ex
+iron crown ex
+raging bolt ex
+bianca's devotion
+eri
+morty's conviction
+salvatore
+iron leaves ex
+gouging fire ex
+walking wake ex
+iron crown ex
+iron boulder ex
+raging bolt ex
+sprigatito
+floragato
+meowscarada ex
+fuecoco
+crocalor
+skeledirge ex
+quaxly
+quaxwell
+quaquaval ex
+mabosstiff ex
+sprigatito ex
+pikachu
+feraligatr
+metang
+koraidon
+miraidon
+cyclizar
+cleffa
+carvanha
+bellibolt
+flutter mane
+iron thorns
+iono
+tangela
+tangrowth
+pinsir
+spinarak
+sunflora
+sunkern
+ariados
+heracross
+volbeat
+illumise
+leafeon
+phantump
+trevenant
+rillaboom
+dipplin
+sinistcha ex
+grookey
+thwackey
+applin
+iron leaves
+poltchageist
+poltchageist
+sinistcha
+teal mask ogerpon
+teal mask ogerpon ex
+vulpix
+ninetales
+slugma
+magcargo ex
+torkoal
+chimchar
+monferno
+infernape
+darumaka
+darmanitan
+litwick
+lampent
+chandelure
+chi yu
+hearthflame mask ogerpon ex
+poliwag
+poliwhirl
+poliwrath
+goldeen
+seaking
+jynx
+corphish
+crawdaunt
+feebas
+milotic
+snorunt
+glalie
+froslass
+froakie
+frogadier
+glaceon
+phione
+cramorant
+iron bundle
+finizen
+palafin
+palafin ex
+walking wake
+wellspring mask ogerpon ex
+zapdos
+shinx
+luxio
+emolga
+luxray ex
+helioptile
+heliolisk
+morpeko
+tadbulb
+bellibolt
+wattrel
+kilowattrel
+iron thorns ex
+clefairy
+clefable
+abra
+kadabra
+alakazam
+girafarig
+farigiraf
+floette
+chimecho
+flabébé
+swirlix
+florges
+slurpuff
+sandygast
+palossand
+enamorus
+scream tail ex
+munkidori
+fezandipiti
+sandshrew
+hisuian growlithe
+sandslash
+hisuian arcanine
+nosepass
+probopass
+timburr
+gurdurr
+conkeldurr
+greninja ex
+hawlucha
+glimmet
+glimmora
+ting lu
+okidogi
+cornerstone mask ogerpon ex
+poochyena
+mightyena
+venipede
+whirlipede
+scolipede
+brute bonnet
+skarmory
+aron
+lairon
+aggron
+heatran
+varoom
+revavroom
+applin
+dipplin
+dreepy
+drakloak
+dragapult ex
+tatsugiri
+farfetch'd
+chansey
+blissey ex
+eevee
+snorlax
+aipom
+ambipom
+ducklett
+swanna
+bloodmoon ursaluna ex
+accompanying flute
+bug catching set
+caretaker
+carmine
+community center
+cook
+enhanced hammer
+festival grounds
+hassel
+handheld fan
+hyper aroma
+jamming tower
+kieran
+lana's aid
+love ball
+lucian
+lucky helmet
+ogre's mask
+perrin
+raifort
+scoop up cyclone
+secret box
+survival brace
+unfair stamp
+boomerang energy
+legacy energy
+pinsir
+sunflora
+dipplin
+poltchageist
+torkoal
+infernape
+froslass
+phione
+cramorant
+wattrel
+chimecho
+heliolisk
+enamorus
+hisuian growlithe
+probopass
+timburr
+lairon
+applin
+tatsugiri
+chansey
+eevee
+sinistcha ex
+teal mask ogerpon ex
+magcargo ex
+wellspring mask ogerpon ex
+hearthflame mask ogerpon ex
+palafin ex
+luxray ex
+iron thorns ex
+scream tail ex
+greninja ex
+cornerstone mask ogerpon ex
+dragapult ex
+blissey ex
+bloodmoon ursaluna ex
+caretaker
+carmine
+hassel
+kieran
+lana's aid
+lucian
+perrin
+teal mask ogerpon ex
+sinistcha ex
+greninja ex
+hearthflame mask ogerpon ex
+wellspring mask ogerpon ex
+cornerstone mask ogerpon ex
+bloodmoon ursaluna ex
+kieran
+lana's aid
+carmine
+perrin
+teal mask ogerpon ex
+bloodmoon ursaluna ex
+buddy buddy poffin
+enhanced hammer
+rescue board
+luminous energy
+great tusk ex
+iron treads ex
+charizard ex
+shroodle
+grafaiai ex
+houndoom ex
+melmetal ex
+armarouge ex
+pikachu ex
+mareep
+flaaffy
+ampharos
+darkrai ex
+pawniard
+bisharp
+kingambit
+picnicker
+thwackey
+infernape
+froslass
+tatsugiri
+toxel
+pupitar
+revavroom
+snorlax
+teal mask ogerpon
+armarouge ex
+palafin ex
+walking wake ex
+iron leaves ex
+miraidon
+joltik
+galvantula
+rowlet
+dartrix
+decidueye
+tapu bulu
+houndour
+houndoom
+iron moth
+horsea
+seadra
+kingdra ex
+sneasel
+weavile
+revavroom ex
+drowzee
+hypno
+duskull
+dusclops
+dusknoir
+cresselia
+sylveon
+croagunk
+toxicroak
+bloodmoon ursaluna
+slither wing
+zubat
+golbat
+crobat
+absol
+zorua
+zoroark
+inkay
+malamar
+yveltal
+okidogi ex
+munkidori ex
+fezandipiti ex
+pecharunt ex
+genesect
+cufant
+copperajah
+varoom
+axew
+fraxure
+haxorus
+kyurem
+meowth
+persian
+eevee
+furfrou
+stufful
+bewear
+academy at night
+binding mochi
+cassiopeia
+colress's tenacity
+dangerous laser
+janine's secret art
+neutralization zone
+night stretcher
+poké vital a
+powerglass
+xerosic's machinations
+tapu bulu
+houndoom
+horsea
+duskull
+dusclops
+dusknoir
+cresselia
+munkidori
+fezandipiti
+okidogi
+zorua
+cufant
+fraxure
+persian
+bewear
+kingdra ex
+revavroom ex
+okidogi ex
+munkidori ex
+fezandipiti ex
+pecharunt ex
+cassiopeia
+colress's tenacity
+janine's secret art
+xerosic's machinations
+okidogi ex
+munkidori ex
+fezandipiti ex
+pecharunt ex
+cassiopeia
+pecharunt ex
+earthen vessel
+powerglass
+basic darkness energy
+basic metal energy
+venusaur ex
+ledyba
+ledian
+lileep
+celebi
+cradily
+carnivine
+grubbin
+mow rotom
+gossifleur
+eldegoss
+applin
+dipplin
+hydrapple ex
+nymble
+lokix
+toedscool
+toedscruel
+ponyta
+rapidash
+pansear
+reshiram
+salazzle
+salandit
+turtonator
+scorbunny
+raboot
+cinderace ex
+blastoise ex
+lapras
+charcadet
+lapras ex
+marill
+azumarill
+finneon
+lumineon
+tirtouga
+carracosta
+froakie
+frogadier
+greninja ex
+crabominable
+drednaw
+chewtle
+veluza
+electabuzz
+electivire
+chinchou
+lanturn
+joltik
+galvantula ex
+charjabug
+vikavolt
+zeraora
+togedemaru
+pawmi
+slowpoke
+slowking
+mewtwo
+drifloon
+drifblim
+yamask
+comfey
+milcery
+alcremie
+fidough
+dachsbun ex
+flittle
+espathra
+greavard
+iron boulder
+cubone
+marowak
+rhyhorn
+rhydon
+rhyperior
+meditite
+meditite
+medicham
+medicham ex
+riolu
+lucario ex
+mienfoo
+mienshao
+pancham
+diancie
+crabrawler
+falinks
+garganacl ex
+koraidon
+gulpin
+swalot
+pangoro
+impidimp
+morgrem
+grimmsnarl
+bombirdier
+jirachi
+klink
+klang
+klinklang
+meltan
+meltan
+melmetal
+melmetal ex
+duraludon
+archaludon
+varoom
+revavroom
+orthworm ex
+raging bolt
+tauros
+eevee
+hoothoot
+noctowl
+glameow
+purugly
+fan rotom
+bouffalant
+tornadus
+fletchling
+fletchinder
+talonflame
+wooloo
+dubwool
+lechonk
+cyclizar
+terapagos ex
+antique cover fossil
+antique root fossil
+area zero underdepths
+briar
+crispin
+deluxe bomb
+glass trumpet
+grand tree
+gravity gemstone
+kofu
+lacey
+occa berry
+payapa berry
+sparkling crystal
+bulbasaur
+ledian
+lileep
+turtonator
+raboot
+squirtle
+joltik
+crabominable
+zeraora
+milcery
+gulpin
+archaludon
+meditite
+hydrapple ex
+lapras ex
+cinderace ex
+galvantula ex
+dachsbun ex
+medicham ex
+orthworm ex
+briar
+crispin
+kofu
+lacey
+hydrapple ex
+galvantula ex
+dachsbun ex
+terapagos ex
+briar
+lacey
+terapagos ex
+area zero underdepths
+bravery charm
+basic fire energy
+basic water energy
+basic lightning energy
+basic metal energy
+basic grass energy
+basic fighting energy
+basic psychic energy
+basic darkness energy
+kingambit
+kingdra ex
+greninja ex
+pecharunt
+drifblim
+crabominable
+bouffalant
+ledian
+horsea
+latias
+victini ex
+tinkaton
+porygon2
+noctowl
+miraidon ex
+gouging fire ex
+raging bolt ex
+iron crown ex
+iron boulder ex
+pecharunt
+paradise resort
+exeggcute
+exeggcute
+exeggutor
+durant ex
+scatterbug
+spewpa
+vivillon
+morelull
+shiinotic
+dhelmise
+zarude
+capsakid
+rellor
+rabsca
+wo chien
+vulpix
+ninetales
+paldean tauros
+ho oh
+castform sunny form
+victini
+pansear
+simisear
+larvesta
+volcarona
+oricorio
+sizzlipede
+centiskorch
+fuecoco
+crocalor
+skeledirge
+charcadet
+charcadet
+armarouge
+ceruledge
+ceruledge ex
+scovillain ex
+gouging fire
+paldean tauros
+mantine
+feebas
+milotic ex
+spheal
+sealeo
+walrein
+shellos
+cryogonal
+black kyurem ex
+bruxish
+quaxly
+quaxwell
+quaquaval
+cetoddle
+cetitan
+iron bundle
+chien pao
+pikachu ex
+magnemite
+magneton
+magnezone
+rotom
+blitzle
+zebstrika
+stunfisk
+tapu koko
+wattrel
+kilowattrel
+kilowattrel ex
+miraidon
+togepi
+togetic
+togekiss
+marill
+azumarill
+smoochum
+latias ex
+latios
+uxie
+mesprit
+azelf
+sigilyph
+yamask
+cofagrigus
+espurr
+meowstic
+sylveon ex
+dedenne
+xerneas
+oricorio
+sandygast
+palossand ex
+tapu lele
+indeedee
+flittle
+espathra
+flutter mane
+gimmighoul
+mankey
+primeape
+annihilape
+paldean tauros
+phanpy
+donphan
+trapinch
+vibrava
+flygon ex
+gastrodon
+drilbur
+excadrill
+landorus
+passimian
+clobbopus
+grapploct
+glimmet
+glimmora
+koraidon
+deino
+zweilous
+hydreigon ex
+shroodle
+grafaiai
+alolan diglett
+alolan dugtrio
+skarmory
+registeel
+bronzor
+bronzong
+klefki
+duraludon
+archaludon ex
+gholdengo
+iron crown
+alolan exeggutor ex
+altaria
+dialga
+palkia
+turtonator
+applin
+flapple
+appletun
+eternatus
+tatsugiri ex
+eevee
+snorlax
+slakoth
+vigoroth
+slaking ex
+swablu
+zangoose
+kecleon
+bouffalant
+rufflet
+braviary
+helioptile
+heliolisk
+oranguru
+tandemaus
+maushold
+cyclizar ex
+flamigo ex
+terapagos
+amulet of hope
+babiri berry
+brilliant blender
+call bell
+chill teaser toy
+clemont's quick wit
+colbur berry
+counter gain
+cyrano
+deduction kit
+dragon elixir
+drasna
+drayton
+dusk ball
+energy search pro
+gravity mountain
+jasmine's gaze
+lisia's appeal
+lively stadium
+meddling memo
+megaton blower
+miracle headset
+passho berry
+precious trolley
+scramble switch
+surfer
+technical machine: fluorite
+tera orb
+tyme
+enriching energy
+exeggcute
+vivillon
+shiinotic
+castform sunny form
+larvesta
+ceruledge
+feebas
+spheal
+bruxish
+cetitan
+stunfisk
+latios
+mesprit
+phanpy
+vibrava
+clobbopus
+alolan dugtrio
+skarmory
+flapple
+appletun
+slakoth
+kecleon
+braviary
+durant ex
+scovillain ex
+milotic ex
+black kyurem ex
+pikachu ex
+latias ex
+palossand ex
+flygon ex
+hydreigon ex
+archaludon ex
+alolan exeggutor ex
+tatsugiri ex
+slaking ex
+cyclizar ex
+clemont's quick wit
+cyrano
+drasna
+drayton
+jasmine's gaze
+lisia's appeal
+surfer
+durant ex
+milotic ex
+pikachu ex
+latias ex
+hydreigon ex
+archaludon ex
+alolan exeggutor ex
+clemont's quick wit
+drayton
+jasmine's gaze
+lisia's appeal
+pikachu ex
+alolan exeggutor ex
+counter gain
+gravity mountain
+night stretcher
+jet energy
+gouging fire
+chien pao
+magneton
+indeedee
+wooper
+quagsire
+zapdos
+pachirisu
+magneton
+squawkabilly ex
+charizard ex
+houndstone ex
+cinderace ex
+lapras ex
+terapagos ex

--- a/server/util/stripName.js
+++ b/server/util/stripName.js
@@ -1,0 +1,47 @@
+async function cleanName(name) {
+    const exclude = ["stage", "stage1", "stage2", "basic"];
+    const lower = name.map(x => x.toLowerCase());
+    let cleaned = "";
+
+    for (let i = 0; i < lower.length; i++) {
+        if (!exclude.includes(lower[i])) {
+            cleaned += lower[i] + " ";
+        }
+    }
+
+    return cleaned.trim();
+}
+
+module.exports = { cleanName };
+
+// // Test case 1: Basic Test Case
+// console.log(cleanName(["stage", "basic", "Name", "stage2", "test"])); 
+// // Expected output: "name test"
+
+// // Test case 2: No words to exclude
+// console.log(cleanName(["hello", "world", "foo", "bar"])); 
+// // Expected output: "hello world foo bar"
+
+// // Test case 3: All words are excluded
+// console.log(cleanName(["stage", "stage1", "stage2", "basic"])); 
+// // Expected output: ""
+
+// // Test case 4: Mixed case input
+// console.log(cleanName(["STAGE", "Basic", "Test", "hello"])); 
+// // Expected output: "test hello" (case insensitive)
+
+// console.log(cleanName(["Hello", "WORLD", "Stage", "BASIC"])); 
+// // Expected output: "hello world"
+
+// // Test case 5: Empty input list
+// console.log(cleanName([])); 
+// // Expected output: ""
+
+// // Test case 6: Single word input, excluded
+// console.log(cleanName(["stage"])); 
+// // Expected output: ""
+
+// // Test case 7: Single word input, not excluded
+// console.log(cleanName(["Hello"])); 
+// // Expected output: "hello"
+

--- a/server/util/stripName.js
+++ b/server/util/stripName.js
@@ -1,50 +1,127 @@
-async function cleanName(name) {
-    const exclude = ["stage", "stage1", "stage2", "basic"];
-    const lower = name.map(x => x.toLowerCase());
-    let cleaned = "";
+// async function cleanName(name) {
+//     const top = name.slice(0,2)
+//     console.log("Pre Parsed Text:", top)
+//     const exclude = ["stage", "stage1", "stage2", "basic", "evolves", "from", "hp"];
+//     const lower = top.map(x => x.toLowerCase());
+//     let cleaned = "";
 
-    for (let i = 0; i < lower.length; i++) {
-        // change wmax to whatever its reading vmax as
-        if (lower[i] === "wmax") {
-            cleaned += "vmax" + " ";
-        } else if (!exclude.includes(lower[i])) {
-            cleaned += lower[i] + " ";
+//     for (let i = 0; i < lower.length; i++) {
+//         // change wmax to whatever its reading vmax as
+//         if (lower[i] === "wax") {
+//             cleaned += "vmax" + " ";
+//         } else if (!exclude.includes(lower[i])) {
+//             cleaned += lower[i] + " ";
+//         }
+//     }
+
+//     return cleaned.trim();
+// }
+
+const fs = require('fs');
+const path = require('path');  // For handling file paths
+
+async function wordExistsInFile(word) {
+    try {
+        // Define the file path (adjust if necessary)
+        const filePath = path.join(__dirname, 'pnames.txt');  // Replace 'pnames.txt' with your file name
+        
+        // Read the file content
+        const data = await fs.promises.readFile(filePath, 'utf8');
+        
+        // Split the content into lines or words
+        const words = data.split('\n').map(line => line.trim().toLowerCase()); // Assuming each word is on a new line
+        
+        // Check if the word exists in the content (case-insensitive check)
+        if (words.includes(word)) {
+            // console.log(`The word "${word}" exists in the file.`);
+            return true;
+        } else {
+            // console.log(`The word "${word}" does NOT exist in the file.`);
+            return false;
         }
+    } catch (err) {
+        console.error('Error reading file:', err);
+        return false;
     }
-
-    return cleaned.trim();
 }
 
+async function cleanName(name) {
+    try {
+        // // Define the file path (adjust if necessary)
+        // const filePath = path.join(__dirname, 'pnames.txt');
+        
+        // // Read the file content
+        // const data = await fs.promises.readFile(filePath, 'utf8');
+        
+        // Create a Set from the file data (each line as an individual word)
+        // const s = new Set(data.split('\n').map(line => line.trim().toLowerCase()));
+
+        // Define the words to exclude
+        const exclude = new Set(["stage", "stage1", "stage2", "basic", "evolves"]);
+
+        // console.log(name)
+
+        // Process the input name array
+        let cleaned = "";
+        for (let word of name) {
+            const lowerWord = word.toLowerCase();
+            // console.log(lowerWord); // Debug log to see what word is being checked
+    
+            // Split lowerWord into individual words (if it contains spaces) and check for exclusion
+            const wordsInLowerWord = lowerWord.split(/\s+/); // Split by spaces or other whitespace
+    
+            // Check if any word in the lowerWord is in the exclude set
+            const isExcluded = wordsInLowerWord.some(w => exclude.has(w));
+    
+            // If none of the words in lowerWord are excluded and the word exists in the file, add to cleaned
+            for (let lowerWord of wordsInLowerWord) {
+                if (isExcluded) {
+                    break
+                } else if (await wordExistsInFile(lowerWord)) {
+                    cleaned += lowerWord + " ";
+                }
+            }
+        }
+
+        return cleaned.trim();
+    } catch (err) {
+        console.error('Error reading file:', err);
+        return '';
+    }
+}
+
+// Example of calling getName
+
+// async function testCleanName() {
+//     // const result = await cleanName(["Stage", 'VMAX Sylveon', "Evolves", "Charmander", "Basic", "fire dragon"])
+//     const result = await cleanName([
+//         'VMAX Sylveon VMAX',
+//         'Evolves from Sylveon V',
+//         'Dynamax',
+//         '310',
+//         'RAPID',
+//         'STRIKE',
+//         'Precious Touch',
+//         'Attach an Energy card from your hand to I of your',
+//         'Benched Pokémon. If you do, heal 120 damage from that',
+//         'Pokémon.',
+//         'Max Harmony',
+//         '70+',
+//         'This attack does 30 more damage for each different type',
+//         'of Pokémon on your Bench.',
+//         'weakness x2 resistance',
+//         'illus. Ryota Murayama',
+//         '? 211/203⭑',
+//         'VMAX rule',
+//         'retreat',
+//         'When your Pokémon VMAX',
+//         'is Knocked Out, your opponent takes 3 Prize cards.',
+//         '02021 Pokémon/Nintendo/Creatures/GAME FREAK',
+//         'Evolves'
+//       ]);
+//     console.log(result);  // Output should be "pikachu charmander" (if those names are in the 'pnames.txt' file)
+// }
+
+// testCleanName();
+
 module.exports = { cleanName };
-
-// // Test case 1: Basic Test Case
-// console.log(cleanName(["stage", "basic", "Name", "stage2", "test"])); 
-// // Expected output: "name test"
-
-// // Test case 2: No words to exclude
-// console.log(cleanName(["hello", "world", "foo", "bar"])); 
-// // Expected output: "hello world foo bar"
-
-// // Test case 3: All words are excluded
-// console.log(cleanName(["stage", "stage1", "stage2", "basic"])); 
-// // Expected output: ""
-
-// // Test case 4: Mixed case input
-// console.log(cleanName(["STAGE", "Basic", "Test", "hello"])); 
-// // Expected output: "test hello" (case insensitive)
-
-// console.log(cleanName(["Hello", "WORLD", "Stage", "BASIC"])); 
-// // Expected output: "hello world"
-
-// // Test case 5: Empty input list
-// console.log(cleanName([])); 
-// // Expected output: ""
-
-// // Test case 6: Single word input, excluded
-// console.log(cleanName(["stage"])); 
-// // Expected output: ""
-
-// // Test case 7: Single word input, not excluded
-// console.log(cleanName(["Hello"])); 
-// // Expected output: "hello"
-

--- a/server/util/stripName.js
+++ b/server/util/stripName.js
@@ -4,7 +4,10 @@ async function cleanName(name) {
     let cleaned = "";
 
     for (let i = 0; i < lower.length; i++) {
-        if (!exclude.includes(lower[i])) {
+        // change wmax to whatever its reading vmax as
+        if (lower[i] === "wmax") {
+            cleaned += "vmax" + " ";
+        } else if (!exclude.includes(lower[i])) {
             cleaned += lower[i] + " ";
         }
     }

--- a/server/util/stripName.js
+++ b/server/util/stripName.js
@@ -38,7 +38,7 @@ async function cleanName(name) {
         // const s = new Set(data.split('\n').map(line => line.trim().toLowerCase()));
 
         // Define the words to exclude
-        const exclude = new Set(["stage", "stage1", "stage2", "basic", "evolves"]);
+        const exclude = new Set(["stage", "stage1", "stage2", "basic", "evolves", "ability"]);
 
         // console.log(name)
 

--- a/server/util/stripName.js
+++ b/server/util/stripName.js
@@ -1,22 +1,3 @@
-// async function cleanName(name) {
-//     const top = name.slice(0,2)
-//     console.log("Pre Parsed Text:", top)
-//     const exclude = ["stage", "stage1", "stage2", "basic", "evolves", "from", "hp"];
-//     const lower = top.map(x => x.toLowerCase());
-//     let cleaned = "";
-
-//     for (let i = 0; i < lower.length; i++) {
-//         // change wmax to whatever its reading vmax as
-//         if (lower[i] === "wax") {
-//             cleaned += "vmax" + " ";
-//         } else if (!exclude.includes(lower[i])) {
-//             cleaned += lower[i] + " ";
-//         }
-//     }
-
-//     return cleaned.trim();
-// }
-
 const fs = require('fs');
 const path = require('path');  // For handling file paths
 


### PR DESCRIPTION
Added a filter to clean up the parsed text from image detection - strips all words besides the pokemon name and catches for abilities, evos, etc. Since the search function can bring up a single card based on part of the name + the number, it is unnecessary to keep ex/mega/vmax in the name.